### PR TITLE
Fix container name inconsistency in file scenarios.tpl

### DIFF
--- a/test/plugins/runner-helper/templates/scenarios.tpl
+++ b/test/plugins/runner-helper/templates/scenarios.tpl
@@ -19,8 +19,8 @@
 set -ex
 
 project_name=$(echo "{{.Context.ScenarioName}}" |sed -e "s/\.//g" |awk '{print tolower($0)}')
-service_container_name="${project_name}_service_1"
-validator_container_name="${project_name}_validator_1"
+service_container_name="${project_name}-service-1"
+validator_container_name="${project_name}-validator-1"
 docker-compose -p "${project_name}" -f "{{.DockerComposeFilePath}}" up -d --build
 
 sleep 3

--- a/test/plugins/runner-helper/templates/scenarios.tpl
+++ b/test/plugins/runner-helper/templates/scenarios.tpl
@@ -18,9 +18,20 @@
 
 set -ex
 
+compose_version=$(docker-compose version --short)
+
+if [[ $compose_version =~ ^(v)?1 ]]; then
+    separator="_"
+elif [[ $compose_version =~ ^(v)?2 ]]; then
+    separator="-"
+else
+    echo "Unsupported Docker Compose version: $compose_version"
+    exit 1
+fi
+
 project_name=$(echo "{{.Context.ScenarioName}}" |sed -e "s/\.//g" |awk '{print tolower($0)}')
-service_container_name="${project_name}-service-1"
-validator_container_name="${project_name}-validator-1"
+service_container_name="${project_name}${separator}service${separator}1"
+validator_container_name="${project_name}${separator}validator${separator}1"
 docker-compose -p "${project_name}" -f "{{.DockerComposeFilePath}}" up -d --build
 
 sleep 3


### PR DESCRIPTION
When running the run.sh script under skywalking-go/test/plugins, the container name service defined in scenarios.tpl appears_ container_ name，validator_ container_ name.The connection symbol in name is "_", while the container's connection symbol is "-" after docker-compose.yml is started, which causes the scenario. sh runtime to be unable to obtain the corresponding information, resulting in run.sh failure


Before change
![Before change](https://github.com/apache/skywalking-go/assets/84159013/1f9bd317-8725-4edd-ad88-94e4f140e38d)

After change
![After change](https://github.com/apache/skywalking-go/assets/84159013/a757e98b-dd0d-43ec-9256-8b44adb25776)
