### PR TITLE
Refactor the global ID generator

### DIFF
--- a/plugins/core/context.go
+++ b/plugins/core/context.go
@@ -33,6 +33,7 @@ type ContextSnapshoter interface {
 type TracingContext struct {
 	activeSpan TracingSpan
 	Runtime    *RuntimeContext
+	ID         *IDContext
 }
 
 func (t *TracingContext) TakeSnapShot(val interface{}) interface{} {
@@ -40,6 +41,7 @@ func (t *TracingContext) TakeSnapShot(val interface{}) interface{} {
 	return &TracingContext{
 		activeSpan: snapshot,
 		Runtime:    t.Runtime.clone(),
+		ID:         NewIDContext(false),
 	}
 }
 
@@ -67,6 +69,7 @@ func NewTracingContext() *TracingContext {
 		Runtime: &RuntimeContext{
 			data: make(map[string]interface{}),
 		},
+		ID: NewIDContext(true),
 	}
 }
 

--- a/plugins/core/id.go
+++ b/plugins/core/id.go
@@ -1,0 +1,98 @@
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Apache Software Foundation (ASF) licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package core
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+var GetGoID = func() int64 {
+	return 0
+}
+
+var (
+	idEpoch          time.Time
+	globalInstanceID string
+)
+
+func init() {
+	idEpoch = time.Date(1900, 0, 0, 0, 0, 0, 0, time.UTC)
+	uuid, err := UUID()
+	if err != nil {
+		panic(err)
+	}
+	globalInstanceID = strings.ReplaceAll(uuid, "-", "")
+}
+
+type IDContext struct {
+	goid     int64
+	lastTime int64
+	seq      int16
+
+	shift    int64
+	shitTime int64
+}
+
+func NewIDContext(getGoIDNow bool) *IDContext {
+	var goid int64
+	if getGoIDNow {
+		goid = GetGoID()
+	}
+	return &IDContext{
+		goid:     goid,
+		lastTime: 0,
+		seq:      0,
+	}
+}
+
+// GenerateGlobalID generates global unique id
+func GenerateGlobalID(ctx *TracingContext) (globalID string, err error) {
+	idContext := ctx.ID
+	if idContext.goid == 0 {
+		idContext.goid = GetGoID()
+	}
+
+	return fmt.Sprintf("%s.%d.%d", globalInstanceID, idContext.goid, idContext.nextID()), nil
+}
+
+func (c *IDContext) nextID() int64 {
+	return c.timestamp()*10000 + int64(c.nextSeq())
+}
+
+func (c *IDContext) timestamp() int64 {
+	now := time.Since(idEpoch).Milliseconds()
+	if now < c.lastTime {
+		if c.shitTime != now {
+			c.shift++
+			c.shitTime = now
+		}
+		return c.shift
+	}
+	c.lastTime = now
+	return now
+}
+
+func (c *IDContext) nextSeq() int16 {
+	if c.seq == 10000 {
+		c.seq = 0
+	}
+	c.seq++
+	return c.seq
+}

--- a/plugins/core/id_test.go
+++ b/plugins/core/id_test.go
@@ -1,0 +1,75 @@
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Apache Software Foundation (ASF) licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package core
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGenerateID(t *testing.T) {
+	ctx := NewTracingContext()
+	id, err := GenerateGlobalID(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.NotEqual(t, "", id, "id should not be empty")
+}
+
+func BenchmarkGenerateID(b *testing.B) {
+	context := NewTracingContext()
+	for i := 0; i < b.N; i++ {
+		_, err := GenerateGlobalID(context)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkGenerateIDParallels(b *testing.B) {
+	b.RunParallel(func(pb *testing.PB) {
+		context := NewTracingContext()
+		for pb.Next() {
+			_, err := GenerateGlobalID(context)
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+}
+
+func BenchmarkUUID(t *testing.B) {
+	for i := 0; i < t.N; i++ {
+		_, err := UUID()
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkUUIDParallels(b *testing.B) {
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			_, err := UUID()
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+}

--- a/plugins/core/tool.go
+++ b/plugins/core/tool.go
@@ -44,11 +44,6 @@ func UUID() (string, error) {
 	return strings.ReplaceAll(id.String(), "-", ""), nil
 }
 
-// GenerateGlobalID generates global unique id
-func GenerateGlobalID() (globalID string, err error) {
-	return UUID()
-}
-
 func ProcessNo() string {
 	if os.Getpid() > 0 {
 		return strconv.Itoa(os.Getpid())

--- a/tools/go-agent/instrument/agentcore/instrument.go
+++ b/tools/go-agent/instrument/agentcore/instrument.go
@@ -177,10 +177,16 @@ var {{.SetGlobalOperatorLinkMethod}} func(interface{})
 //go:linkname {{.GetGlobalOperatorLinkMethod}} {{.GetGlobalOperatorLinkMethod}}
 var {{.GetGlobalOperatorLinkMethod}} func() interface{}
 
+//go:linkname {{.GetGoroutineIDLinkMethod}} {{.GetGoroutineIDLinkMethod}}
+var {{.GetGoroutineIDLinkMethod}} func() int64
+
 func init() {
 	if {{.TLSGetLinkMethod}} != nil && {{.TLSSetLinkMethod}} != nil {
 		GetGLS = {{.TLSGetLinkMethod}}
 		SetGLS = {{.TLSSetLinkMethod}}
+	}
+	if {{.GetGoroutineIDLinkMethod}} != nil {
+		GetGoID = {{.GetGoroutineIDLinkMethod}}
 	}
 	if {{.SetGlobalOperatorLinkMethod}} != nil && {{.GetGlobalOperatorLinkMethod}} != nil {
 		SetGlobalOperator = {{.SetGlobalOperatorLinkMethod}}
@@ -193,10 +199,12 @@ func init() {
 		TLSSetLinkMethod            string
 		SetGlobalOperatorLinkMethod string
 		GetGlobalOperatorLinkMethod string
+		GetGoroutineIDLinkMethod    string
 	}{
 		TLSGetLinkMethod:            consts.TLSGetMethodName,
 		TLSSetLinkMethod:            consts.TLSSetMethodName,
 		SetGlobalOperatorLinkMethod: consts.GlobalTracerSetMethodName,
 		GetGlobalOperatorLinkMethod: consts.GlobalTracerGetMethodName,
+		GetGoroutineIDLinkMethod:    consts.CurrentGoroutineIDGetMethodName,
 	}))
 }

--- a/tools/go-agent/instrument/consts/operator.go
+++ b/tools/go-agent/instrument/consts/operator.go
@@ -27,4 +27,6 @@ const (
 	GlobalTracerGetMethodName = "_skywalking_get_global_operator"
 	GlobalLoggerSetMethodName = "_skywalking_set_global_logger"
 	GlobalLoggerGetMethodName = "_skywalking_get_global_logger"
+
+	CurrentGoroutineIDGetMethodName = "_skywalking_get_goid"
 )

--- a/tools/go-agent/instrument/runtime/instrument.go
+++ b/tools/go-agent/instrument/runtime/instrument.go
@@ -205,12 +205,12 @@ func goroutineChange(tls interface{}) interface{} {
 			GlobalLoggerSetMethodName:     consts.GlobalLoggerSetMethodName,
 			GlobalLoggerGetMethodName:     consts.GlobalLoggerGetMethodName,
 			GoroutineIDGetterMethodName:   consts.CurrentGoroutineIDGetMethodName,
-			GoroutineIDCaster:             r.generateCastGoId("getg().m.curg.goid"),
+			GoroutineIDCaster:             r.generateCastGoID("getg().m.curg.goid"),
 		}),
 	})
 }
 
-func (r *Instrument) generateCastGoId(val string) string {
+func (r *Instrument) generateCastGoID(val string) string {
 	switch r.goIDType {
 	case "int64":
 		return val

--- a/tools/go-agent/instrument/runtime/instrument.go
+++ b/tools/go-agent/instrument/runtime/instrument.go
@@ -92,6 +92,7 @@ func (r *Instrument) AfterEnhanceFile(fromPath, newPath string) error {
 	return nil
 }
 
+// nolint
 func (r *Instrument) WriteExtraFiles(dir string) ([]string, error) {
 	return tools.WriteMultipleFile(dir, map[string]string{
 		"skywalking_tls_operator.go": tools.ExecuteTemplate(`package runtime
@@ -121,6 +122,14 @@ var {{.GlobalLoggerSetMethodName}} = _skywalking_global_logger_set_impl
 
 //go:linkname {{.GlobalLoggerGetMethodName}} {{.GlobalLoggerGetMethodName}}
 var {{.GlobalLoggerGetMethodName}} = _skywalking_global_logger_get_impl
+
+//go:linkname {{.GoroutineIDGetterMethodName}} {{.GoroutineIDGetterMethodName}}
+var {{.GoroutineIDGetterMethodName}} = _skywalking_get_goid_impl
+
+//go:nosplit
+func _skywalking_get_goid_impl() int64 {
+	return getg().m.curg.goid
+}
 
 //go:nosplit
 func _skywalking_tls_get_impl() interface{} {
@@ -176,6 +185,7 @@ func goroutineChange(tls interface{}) interface{} {
 			GlobalLoggerFieldName         string
 			GlobalLoggerSetMethodName     string
 			GlobalLoggerGetMethodName     string
+			GoroutineIDGetterMethodName   string
 		}{
 			TLSFiledName:                  consts.TLSFieldName,
 			TLSGetMethod:                  consts.TLSGetMethodName,
@@ -187,6 +197,7 @@ func goroutineChange(tls interface{}) interface{} {
 			GlobalLoggerFieldName:         consts.GlobalLoggerFieldName,
 			GlobalLoggerSetMethodName:     consts.GlobalLoggerSetMethodName,
 			GlobalLoggerGetMethodName:     consts.GlobalLoggerGetMethodName,
+			GoroutineIDGetterMethodName:   consts.CurrentGoroutineIDGetMethodName,
 		}),
 	})
 }


### PR DESCRIPTION
Following https://github.com/apache/skywalking/issues/10849, I have refactored the ID generator. 
ID generate format(same with java): `{instanceID}.{goid}.{timestamp}{sequence}`. We bind the `IDContext` to each goroutine(using TLS) to reduce the global locker.

Here are simple batch marks for comparison with UUID：
```
goos: darwin
goarch: amd64
pkg: github.com/apache/skywalking-go/plugins/core
cpu: Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
BenchmarkGenerateID
BenchmarkGenerateID-16             	  956929	      1168 ns/op
BenchmarkGenerateIDParallels
BenchmarkGenerateIDParallels-16    	 4309476	       323.3 ns/op
BenchmarkUUID
BenchmarkUUID-16                   	 1000000	      1008 ns/op
BenchmarkUUIDParallels
BenchmarkUUIDParallels-16          	  856684	      1341 ns/op
PASS
```

I will do another bench mark for the agent, If there is no performance issue, I will remove the `UUID` dependency. 