### PR TITLE
bug: Fix plugin version matcher to support capital letters in module paths and versions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,7 @@ Release Notes.
 
 #### Bug Fixes
 * Fix throw panic when log the tracing context before agent core initialized.
+* Fix plugin version matcher `tryToFindThePluginVersion` to support capital letters in module paths and versions.
 
 #### Issues and PR
 - All issues are [here](https://github.com/apache/skywalking/milestone/180?closed=1)

--- a/tools/go-agent/instrument/plugins/instrument.go
+++ b/tools/go-agent/instrument/plugins/instrument.go
@@ -513,10 +513,13 @@ func (i *Instrument) tryToFindThePluginVersion(opts *api.CompileOptions, ins ins
 		// example: github.com/Shopify/sarama
 		basePkg := ins.BasePackage()
 
+		// Capital letters in module paths and versions are escaped using exclamation points
+		// (Azure is escaped as !azure) to avoid conflicts on case-insensitive file systems.
 		// example: github.com/!shopify/sarama
+		// see: https://go.dev/ref/mod
 		escapedBasePkg, _ := module.EscapePath(basePkg)
 
-		// arg example: github.com/!shopify/sarama/@1.34.1/acl.go
+		// arg example: github.com/!shopify/sarama@1.34.1/acl.go
 		_, afterPkg, found := strings.Cut(arg, escapedBasePkg)
 		if !found {
 			return "", fmt.Errorf("could not found the go version of the package %s, go file path: %s", basePkg, arg)

--- a/tools/go-agent/instrument/plugins/instrument.go
+++ b/tools/go-agent/instrument/plugins/instrument.go
@@ -28,6 +28,8 @@ import (
 	"path/filepath"
 	"strings"
 
+	"golang.org/x/mod/module"
+
 	"github.com/pkg/errors"
 
 	"github.com/apache/skywalking-go/plugins/core"
@@ -507,10 +509,15 @@ func (i *Instrument) tryToFindThePluginVersion(opts *api.CompileOptions, ins ins
 		if !strings.HasSuffix(arg, ".go") {
 			continue
 		}
+
+		// example: github.com/Shopify/sarama
 		basePkg := ins.BasePackage()
 
-		// example: github.com/gin-gonic/gin@1.1.1/gin.go
-		_, afterPkg, found := strings.Cut(arg, basePkg)
+		// example: github.com/!shopify/sarama
+		escapedBasePkg, _ := module.EscapePath(basePkg)
+
+		// arg example: github.com/!shopify/sarama/@1.34.1/acl.go
+		_, afterPkg, found := strings.Cut(arg, escapedBasePkg)
 		if !found {
 			return "", fmt.Errorf("could not found the go version of the package %s, go file path: %s", basePkg, arg)
 		}

--- a/tools/go-agent/instrument/plugins/instrument_test.go
+++ b/tools/go-agent/instrument/plugins/instrument_test.go
@@ -19,9 +19,10 @@ package plugins
 
 import (
 	"embed"
+	"testing"
+
 	"github.com/apache/skywalking-go/plugins/core/instrument"
 	"github.com/apache/skywalking-go/tools/go-agent/instrument/api"
-	"testing"
 )
 
 func TestInstrument_tryToFindThePluginVersion(t *testing.T) {

--- a/tools/go-agent/instrument/plugins/instrument_test.go
+++ b/tools/go-agent/instrument/plugins/instrument_test.go
@@ -1,3 +1,20 @@
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Apache Software Foundation (ASF) licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package plugins
 
 import (

--- a/tools/go-agent/instrument/plugins/instrument_test.go
+++ b/tools/go-agent/instrument/plugins/instrument_test.go
@@ -1,0 +1,76 @@
+package plugins
+
+import (
+	"embed"
+	"github.com/apache/skywalking-go/plugins/core/instrument"
+	"github.com/apache/skywalking-go/tools/go-agent/instrument/api"
+	"testing"
+)
+
+func TestInstrument_tryToFindThePluginVersion(t *testing.T) {
+	tests := []struct {
+		name string
+		opts *api.CompileOptions
+		ins  instrument.Instrument
+		want string
+	}{
+		{
+			"normal plugin path",
+			&api.CompileOptions{
+				AllArgs: []string{
+					"github.com/gin-gonic/gin@1.1.1/gin.go",
+				},
+			},
+			NewTestInstrument("github.com/gin-gonic/gin"),
+			"1.1.1",
+		},
+		{
+			"plugin with upper-case path",
+			&api.CompileOptions{
+				AllArgs: []string{
+					"github.com/!shopify/sarama@1.34.1/acl.go",
+				},
+			},
+			NewTestInstrument("github.com/Shopify/sarama"),
+			"1.34.1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			i := &Instrument{}
+			got, _ := i.tryToFindThePluginVersion(tt.opts, tt.ins)
+			if got != tt.want {
+				t.Errorf("tryToFindThePluginVersion() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+type TestInstrument struct {
+	basePackage string
+}
+
+func NewTestInstrument(basePackage string) *TestInstrument {
+	return &TestInstrument{basePackage: basePackage}
+}
+
+func (i *TestInstrument) Name() string {
+	return ""
+}
+
+func (i *TestInstrument) BasePackage() string {
+	return i.basePackage
+}
+
+func (i *TestInstrument) VersionChecker(version string) bool {
+	return true
+}
+
+func (i *TestInstrument) Points() []*instrument.Point {
+	return []*instrument.Point{}
+}
+
+func (i *TestInstrument) FS() *embed.FS {
+	return nil
+}


### PR DESCRIPTION
## Description
When running with `-toolexec`, go module path would be accessed and used as input argument:
```
time="2023-06-15T16:55:11+08:00" level=info msg="executing instrument with args: [-debug /home/jiekun/repo/github.com/skywalking-go /home/jiekun/go/go1.18.10/pkg/tool/linux_amd64/compile -o /tmp/go-build3202628928/b271/_pkg_.a -trimpath /tmp/go-build3202628928/b271=> -p github.com/redis/go-redis/v9 -lang=go1.18 -complete -buildid HdoJ2T0oKPptxg-YD8IU/HdoJ2T0oKPptxg-YD8IU -goversion go1.18.10 -N -l -c=4 -nolocalimports -importcfg /tmp/go-build3202628928/b271/importcfg -pack /home/jiekun/go/pkg/mod/github.com/redis/go-redis/v9@v9.0.5/cluster.go /home/jiekun/go/pkg/mod/github.com/redis/go-redis/v9@v9.0.5/cluster_commands.go /home/jiekun/go/pkg/mod/github.com/redis/go-redis/v9@v9.0.5/command.go /home/jiekun/go/pkg/mod/github.com/redis/go-redis/v9@v9.0.5/commands.go /home/jiekun/go/pkg/mod/github.com/redis/go-redis/v9@v9.0.5/doc.go /home/jiekun/go/pkg/mod/github.com/redis/go-redis/v9@v9.0.5/error.go /home/jiekun/go/pkg/mod/github.com/redis/go-redis/v9@v9.0.5/iterator.go /home/jiekun/go/pkg/mod/github.com/redis/go-redis/v9@v9.0.5/options.go /home/jiekun/go/pkg/mod/github.com/redis/go-redis/v9@v9.0.5/pipeline.go /home/jiekun/go/pkg/mod/github.com/redis/go-redis/v9@v9.0.5/pubsub.go /home/jiekun/go/pkg/mod/github.com/redis/go-redis/v9@v9.0.5/redis.go /home/jiekun/go/pkg/mod/github.com/redis/go-redis/v9@v9.0.5/result.go /home/jiekun/go/pkg/mod/github.com/redis/go-redis/v9@v9.0.5/ring.go /home/jiekun/go/pkg/mod/github.com/redis/go-redis/v9@v9.0.5/script.go /home/jiekun/go/pkg/mod/github.com/redis/go-redis/v9@v9.0.5/sentinel.go /home/jiekun/go/pkg/mod/github.com/redis/go-redis/v9@v9.0.5/tx.go /home/jiekun/go/pkg/mod/github.com/redis/go-redis/v9@v9.0.5/universal.go /home/jiekun/go/pkg/mod/github.com/redis/go-redis/v9@v9.0.5/version.go]"
```

Module path with lower-case character should be like:
```
/home/jiekun/go/pkg/mod/github.com/aws/aws-lambda-go@v1.13.3
/home/jiekun/go/pkg/mod/github.com/oracle/oci-go-sdk@v24.3.0+incompatible
/home/jiekun/go/pkg/mod/github.com/cpu/goacmedns@v0.1.1
```

However, module with capital letters will be stored into an escaped path, like:
```bash
# go get -u github.com/Shopify/sarama@v1.38.1
/home/jiekun/go/pkg/mod/github.com/!shopify/sarama@v1.38.1

# https://github.com/DataDog/agent-payload/blob/master/go.mod
# github.com/DataDog/agent-payload/v5
/home/jiekun/go/pkg/mod/github.com/!data!dog/agent-payload/v5@v5.0.85
```

### Affected Codes
```go
func (i *Instrument) tryToFindThePluginVersion(opts *api.CompileOptions, ins instrument.Instrument) (string, error) {
                ...
                // arg := "github.com/!shopify/sarama@1.34.1/acl.go"
                // basePkg := "github.com/Shopify/sarama"
		basePkg := ins.BasePackage()
		_, afterPkg, found := strings.Cut(arg, basePkg)  // unable to handle
		if !found {
			return "", fmt.Errorf("could not found the go version of the package %s, go file path: %s", basePkg, arg)
		}
                ...
}
```

## Change
### Bug Fix
- Fix plugin version matcher `tryToFindThePluginVersion` to support capital letters in module paths and versions.

### Note
- [X] document is updated if necessary.
- [X] Bug fix are tested.