### PR TITLE
Add Redis Unit test

### DIFF
--- a/plugins/go-redisv9/hook.go
+++ b/plugins/go-redisv9/hook.go
@@ -50,7 +50,7 @@ func (r *redisHook) DialHook(next redis.DialHook) redis.DialHook {
 			GoRedisCacheType+"/"+"dial",
 
 			// peer
-			r.Addr,
+			addr,
 
 			// injector
 			func(k, v string) error {

--- a/plugins/go-redisv9/intercepter.go
+++ b/plugins/go-redisv9/intercepter.go
@@ -19,9 +19,7 @@ package goredisv9
 
 import (
 	"fmt"
-
 	"github.com/apache/skywalking-go/plugins/core/operator"
-
 	redis "github.com/redis/go-redis/v9"
 )
 
@@ -44,14 +42,10 @@ func (g *GoRedisInterceptor) AfterInvoke(invocation operator.Invocation, result 
 	case *redis.Client:
 		c.AddHook(newRedisHook(c.Options().Addr))
 	case *redis.ClusterClient:
-		c.AddHook(newRedisHook(""))
-
 		c.OnNewNode(func(rdb *redis.Client) {
-			rdb.AddHook(newRedisHook(rdb.Options().Addr))
+			rdb.AddHook(newRedisHook(rdb.String()))
 		})
 	case *redis.Ring:
-		c.AddHook(newRedisHook(""))
-
 		c.OnNewNode(func(rdb *redis.Client) {
 			rdb.AddHook(newRedisHook(rdb.Options().Addr))
 		})

--- a/plugins/go-redisv9/intercepter.go
+++ b/plugins/go-redisv9/intercepter.go
@@ -37,7 +37,6 @@ func (g *GoRedisInterceptor) AfterInvoke(invocation operator.Invocation, result 
 	if !ok {
 		return fmt.Errorf("go-redis :skyWalking cannot create hook for client not match UniversalClient: %T", rdb)
 	}
-
 	switch c := rdb.(type) {
 	case *redis.Client:
 		c.AddHook(newRedisHook(c.Options().Addr))

--- a/plugins/go-redisv9/intercepter.go
+++ b/plugins/go-redisv9/intercepter.go
@@ -46,7 +46,7 @@ func (g *GoRedisInterceptor) AfterInvoke(invocation operator.Invocation, result 
 		})
 	case *redis.Ring:
 		c.OnNewNode(func(rdb *redis.Client) {
-			rdb.AddHook(newRedisHook(rdb.Options().Addr))
+			rdb.AddHook(newRedisHook(rdb.String()))
 		})
 	default:
 		return fmt.Errorf("go-redis :skyWalking cannot create hook for the unsupported client type: %T", c)

--- a/plugins/go-redisv9/intercepter_test.go
+++ b/plugins/go-redisv9/intercepter_test.go
@@ -1,0 +1,33 @@
+package goredisv9
+
+import (
+	"context"
+	"github.com/apache/skywalking-go/plugins/core"
+	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/assert"
+	"testing"
+	"time"
+)
+
+func init() {
+	core.ResetTracingContext()
+}
+
+func TestInvoke(t *testing.T) {
+	defer core.ResetTracingContext()
+
+	interceptor := &GoRedisInterceptor{}
+	clusterClient := redis.NewClusterClient(&redis.ClusterOptions{
+		Addrs:          []string{"localhost:6379", "localhost:7379"},
+		DialTimeout:    time.Second * 10,
+		PoolSize:       10,
+		RouteByLatency: true,
+	})
+	err := interceptor.AfterInvoke(nil, clusterClient)
+	assert.Nil(t, err, "failed to invoke AfterInvoke")
+	status, err := clusterClient.Ping(context.Background()).Result()
+	if status != "PONG" {
+		t.Fatalf("err: %v", err)
+	}
+	clusterClient.Get(context.Background(), "test").Val()
+}

--- a/plugins/go-redisv9/intercepter_test.go
+++ b/plugins/go-redisv9/intercepter_test.go
@@ -13,12 +13,12 @@ func init() {
 	core.ResetTracingContext()
 }
 
-func TestInvoke(t *testing.T) {
+func TestRedisClientInvoke(t *testing.T) {
 	defer core.ResetTracingContext()
 
 	interceptor := &GoRedisInterceptor{}
 	clusterClient := redis.NewClusterClient(&redis.ClusterOptions{
-		Addrs:          []string{"localhost:6379", "localhost:7379"},
+		Addrs:          []string{"localhost:6379"},
 		DialTimeout:    time.Second * 10,
 		PoolSize:       10,
 		RouteByLatency: true,
@@ -26,8 +26,42 @@ func TestInvoke(t *testing.T) {
 	err := interceptor.AfterInvoke(nil, clusterClient)
 	assert.Nil(t, err, "failed to invoke AfterInvoke")
 	status, err := clusterClient.Ping(context.Background()).Result()
-	if status != "PONG" {
-		t.Fatalf("err: %v", err)
-	}
-	clusterClient.Get(context.Background(), "test").Val()
+	assert.Nil(t, err, "ping err")
+	assert.Equal(t, "PONG", status, "should be PONG")
+}
+
+func TestRedisClusterClientInvoke(t *testing.T) {
+	defer core.ResetTracingContext()
+
+	interceptor := &GoRedisInterceptor{}
+	clusterClient := redis.NewClusterClient(&redis.ClusterOptions{
+		Addrs:          []string{"localhost:6479", "localhost:6579"},
+		DialTimeout:    time.Second * 10,
+		PoolSize:       10,
+		RouteByLatency: true,
+	})
+	err := interceptor.AfterInvoke(nil, clusterClient)
+	assert.Nil(t, err, "failed to invoke AfterInvoke")
+	status, err := clusterClient.Ping(context.Background()).Result()
+	assert.Nil(t, err, "ping err")
+	assert.Equal(t, "PONG", status, "should be PONG")
+}
+
+func TestRedisRingClientInvoke(t *testing.T) {
+	defer core.ResetTracingContext()
+
+	interceptor := &GoRedisInterceptor{}
+	clusterClient := redis.NewRing(&redis.RingOptions{
+		Addrs: map[string]string{
+			"shard1": "localhost:7000",
+			"shard2": "localhost:7001",
+		},
+		DialTimeout: time.Second * 10,
+		PoolSize:    10,
+	})
+	err := interceptor.AfterInvoke(nil, clusterClient)
+	assert.Nil(t, err, "failed to invoke AfterInvoke")
+	status, err := clusterClient.Ping(context.Background()).Result()
+	assert.Nil(t, err, "ping err")
+	assert.Equal(t, "PONG", status, "should be PONG")
 }

--- a/plugins/go-redisv9/intercepter_test.go
+++ b/plugins/go-redisv9/intercepter_test.go
@@ -1,3 +1,20 @@
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Apache Software Foundation (ASF) licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package goredisv9
 
 import (


### PR DESCRIPTION
`c.AddHook(newRedisHook(""))` in cluster client, ring client may lead err msg: "go-redis :skyWalking failed to create exit span, got error: parameter are nil"