### PR TITLE
fix: CI test build on macos failed

### DIFF
--- a/.github/workflows/plugin-tests.yaml
+++ b/.github/workflows/plugin-tests.yaml
@@ -29,8 +29,8 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [ubuntu, macos]
-    runs-on: ${{ matrix.os }}-latest
+        os: [ubuntu-latest, macos-13]
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 60
     steps:
       - name: Set up Go 1.18
@@ -41,6 +41,7 @@ jobs:
         if: runner.os == 'macos'
         run: |
           brew install docker
+          brew install colima
           colima start
 
           # For testcontainers to find the Colima socket
@@ -91,7 +92,7 @@ jobs:
           submodules: true
       - uses: actions/download-artifact@v2
         with:
-          name: test-tools-ubuntu
+          name: test-tools-ubuntu-latest
           path: test/plugins/dist
       - name: Setup Tools
         run: |
@@ -113,7 +114,7 @@ jobs:
     name: gin-macos
     needs:
       - build
-    runs-on: macos-latest
+    runs-on: macos-13
     timeout-minutes: 90
     steps:
       - uses: actions/checkout@v2
@@ -121,12 +122,17 @@ jobs:
           submodules: true
       - uses: actions/download-artifact@v2
         with:
-          name: test-tools-macos
+          name: test-tools-macos-13
           path: test/plugins/dist
+      - name: Set up Go 1.18
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.18
       - name: Setup docker (missing on MacOS)
         if: runner.os == 'macos'
         run: |
           brew install docker docker-compose
+          brew install colima
           colima start
 
           # For testcontainers to find the Colima socket

--- a/.github/workflows/skywalking-go.yaml
+++ b/.github/workflows/skywalking-go.yaml
@@ -47,9 +47,9 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [ ubuntu, macos, windows ]
+        os: [ ubuntu-latest, macos-13, windows-latest ]
         go-version: [ 1.18, 1.19 ]
-    runs-on: ${{ matrix.os }}-latest
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 60
     steps:
       - name: Set up Go ${{ matrix.go-version }}


### PR DESCRIPTION
### Description:

![Screenshot_20230822_210101](https://github.com/apache/skywalking-go/assets/93872575/15cf379d-f3cf-4111-ba1b-a4d26d9c19f2)

`Build Plugin Test On macos` was failed because `error starting vm: error at 'starting': exit status 1`

### Change:

Build on `macos-latest` --> Build on  `macos-13`
