### PR TITLE
fix header Sw8 in request.txt

### DIFF
--- a/docs/en/agent/performance-tests.md
+++ b/docs/en/agent/performance-tests.md
@@ -51,7 +51,7 @@ Install the [Vegeta service](https://github.com/tsenart/vegeta#install) on the s
 
 ```
 GET http://${CONSUMER_IP}:8080/consumer
-Sw8: 1-MWYyZDRiZjQ3YmY3MTFlYWI3OTRhY2RlNDgwMDExMjI=-MWU3YzIwNGE3YmY3MTFlYWI4NThhY2RlNDgwMDExMjI=-0-c2VydmljZQ==-aW5zdGFuY2U=-cHJvcGFnYXRpb24=-cHJvcGFnYXRpb246NTU2Ng=="
+Sw8: 1-MWYyZDRiZjQ3YmY3MTFlYWI3OTRhY2RlNDgwMDExMjI=-MWU3YzIwNGE3YmY3MTFlYWI4NThhY2RlNDgwMDExMjI=-0-c2VydmljZQ==-aW5zdGFuY2U=-cHJvcGFnYXRpb24=-cHJvcGFnYXRpb246NTU2Ng==
 ```
 
 Please replace the above `CONSUMER_IP` with the real IP address of the consumer instance.


### PR DESCRIPTION
remove the last character(") of the last part in Sw8(AddressUsedAtClient) which cause base64 decode error.

error info:
```
skywalking-go 2023/09/11 11:04:29 execute interceptor before invoke error, instrument name: gin, interceptor name: HTTPInterceptor, function ID: github_com_gin_gonic_gin_EnginehandleHTTPRequest, error: network address parse error: illegal base64 data at input byte 24
```

source code:
```go
	s.AddressUsedAtClient, err = decodeBase64(hh[7])
	if err != nil {
		return errors.Wrap(err, "network address parse error")
	}
```