### PR TITLE
doc: correct the image name to be apache/skywalking-go

### DIFF
--- a/docs/en/setup/docker.md
+++ b/docs/en/setup/docker.md
@@ -8,7 +8,7 @@ Using the SkyWalking Go provided image as the base image, perform file copying a
 
 ```dockerfile
 # import the skywalking go base image
-FROM apache/skywalking-go-agent:<version>-go<go version>
+FROM apache/skywalking-go:<version>-go<go version>
 
 # Copy application code
 COPY /path/to/project /path/to/project


### PR DESCRIPTION
See also the test output:

```shell
[root@ailink-master1 ~]# docker pull apache/skywalking-go-agent:0.1.0-go1.20
Error response from daemon: pull access denied for apache/skywalking-go-agent, repository does not exist or may require 'docker login': denied: requested access to the resource is denied
[root@ailink-master1 ~]# docker pull apache/skywalking-go:0.2.0-go1.20
0.2.0-go1.20: Pulling from apache/skywalking-go
```