### PR TITLE
Provide APIs to user and support correlationContext

### DIFF
--- a/.github/workflows/plugin-tests.yaml
+++ b/.github/workflows/plugin-tests.yaml
@@ -87,6 +87,7 @@ jobs:
           - mux
           - grpc
           - irisv12
+          - trace-activation
     steps:
       - uses: actions/checkout@v2
         with:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@ Release Notes.
 0.3.0
 ------------------
 #### Features
+* Support manual tracing APIs for users.
 
 #### Plugins
 * Support [mux](https://github.com/gorilla/mux) HTTP server framework.
@@ -12,6 +13,7 @@ Release Notes.
 * Support [iris](https://github.com/kataras/iris) framework.
 
 #### Documentation
+* Add `Tracing APIs` document into `Manual APIs`.
 
 #### Bug Fixes
 

--- a/docs/en/advanced-features/manual-apis/toolkit-trace.md
+++ b/docs/en/advanced-features/manual-apis/toolkit-trace.md
@@ -1,0 +1,124 @@
+# Tracing APIs
+
+## Add trace Toolkit
+
+toolkit/trace provides the APIs to enhance the trace context, such as createLocalSpan, createExitSpan, createEntrySpan, log, tag, prepareForAsync and asyncFinish. 
+Add the toolkit dependency to your project.
+
+```go
+import "github.com/apache/skywalking-go/toolkit/trace"
+```
+
+## Use Native Tracing
+
+### Context Carrier
+
+The context carrier is used to pass the context between the difference application.
+
+When creating an Entry Span, you need to obtain the context carrier from the request. When creating an Exit Span, you need to write the context carrier into the target RPC request.
+
+```go
+type ExtractorRef func(headerKey string) (string, error)
+
+type InjectorRef func(headerKey, headerValue string) error
+```
+
+### Create Span
+
+Use `trace.CreateEntrySpan()` API to create entry span, and then use `SpanRef` to contain the reference of created span in agent kernel. 
+
+- The first parameter is operation name of span
+- the second parameter is `InjectorRef`.
+
+```go
+spanRef, err := trace.CreateEntrySpan("operationName", InjectorRef)
+```
+
+Use `trace.CreateLocalSpan()` API to create local span
+
+- the only parameter is the operation name of span.
+
+```go
+spanRef, err := trace.CreateLocalSpan("operationName")
+```
+
+Use `trace.CreateExitSpan()` API to create exit span.
+
+- the first parameter is the operation name of span
+- the second parameter is the remote peer which means the peer address of exit operation.
+- the third parameter is the `ExtractorRef`
+
+```go
+spanRef, err := trace.CreateExitSpan("operationName", "peer", ExtractorRef)
+```
+
+Use `trace.StopSpan()` API to stop current span
+
+```go
+trace.StopSpan()
+```
+
+### Add Span’s Tag and Log
+
+Use `trace.SetLog` to record log in span.
+
+Use `trace.SetTag` to add tag to span, the parameters of tag are two String which are key and value respectively.
+
+```go
+trace.SetLog(...string)
+
+trace.SetTag("key","value")
+```
+
+### Async Prepare/Finish
+
+Use `trace.PrepareAsync()` to make current span still alive until `trace.AsyncFinish()` called.
+
+### Capture/Continue Context Snapshot
+
+1. Use `trace.CaptureContext()` to get tthe segment info and store it in `ContextSnapshotRef`.
+2. Propagate the snapshot context to any other goroutine.
+3. Use `trace.ContinueContext(snapshotRef)` to load the snapshotRef in the target goroutine.
+
+## Reading Context
+
+All following APIs provide **readonly** features for the tracing context from tracing system. The values are only available when the current thread is traced.
+
+- Use `trace.GetTraceID()` API to get traceID.
+
+  ```go
+  traceID := trace.GetTraceID()
+  ```
+
+- Use `trace.GetSegmentID` API to get segmentID.
+
+  ```go
+  segmentID := trace.GetSegmentID()
+  ```
+
+- Use `trace.GetSpanID()` API to get spanID.
+
+  ```go
+  spanID := trace.GetSpanID()
+  ```
+
+## Trace Correlation Context
+
+Trace correlation context APIs provide a way to put custom data in tracing context. All the data in the context will be propagated with the in-wire process automatically.
+
+Use `trace.SetCorrelation()` API to set custom data in tracing context.
+
+```go
+trace.SetCorrelation("key","value")
+```
+
+- Max element count in the correlation context is 3
+- Max value length of each element is 128
+
+CorrelationContext will remove the key when the value is empty.
+
+Use `trace.GetCorrelation` API to get custom data.
+
+```go
+value := trace.GetCorrealtion("key")
+```

--- a/docs/menu.yml
+++ b/docs/menu.yml
@@ -42,6 +42,10 @@ catalog:
           path: /en/agent/plugin-configurations
         - name: Transport Layer Security (TLS)
           path: /en/advanced-features/grpc-tls
+        - name: Manual APIs
+          catalog:
+            - name: Tracing APIs
+              path: /en/advanced-features/manual-apis/toolkit-trace.md
     - name: Plugins
       catalog:
         - name: Supported Libraries

--- a/go.work
+++ b/go.work
@@ -19,6 +19,7 @@ use (
 	./plugins/mux
 	./plugins/grpc
 	./plugins/irisv12
+	./plugins/trace-activation
 
 	./test/benchmark-codebase/consumer
 	./test/benchmark-codebase/provider
@@ -41,10 +42,12 @@ use (
 	./test/plugins/scenarios/mux
 	./test/plugins/scenarios/grpc
     ./test/plugins/scenarios/irisv12
+	./test/plugins/scenarios/trace-activation
 
 	./test/plugins/scenarios/plugin_exclusion
 	./test/plugins/scenarios/runtime_metrics
 
 	./tools/go-agent
 
+	./toolkit
 )

--- a/plugins/core/reporter/api.go
+++ b/plugins/core/reporter/api.go
@@ -35,6 +35,8 @@ type SegmentContext interface {
 	GetSpanID() int32
 	GetParentSpanID() int32
 	GetParentSegmentID() string
+	GetCorrelationContextValue(key string) string
+	SetCorrelationContextValue(key, value string)
 }
 
 // SpanContext defines propagation specification of SkyWalking

--- a/plugins/core/span_tracing.go
+++ b/plugins/core/span_tracing.go
@@ -82,6 +82,17 @@ func (c *SegmentContext) GetParentSegmentID() string {
 	return c.ParentSegmentID
 }
 
+func (c *SegmentContext) GetCorrelationContextValue(key string) string {
+	return c.CorrelationContext[key]
+}
+
+func (c *SegmentContext) SetCorrelationContextValue(key, value string) {
+	c.CorrelationContext[key] = value
+	if value == "" {
+		delete(c.CorrelationContext, key)
+	}
+}
+
 type SegmentSpan interface {
 	TracingSpan
 	GetSegmentContext() SegmentContext

--- a/plugins/core/tracer.go
+++ b/plugins/core/tracer.go
@@ -42,10 +42,10 @@ type Tracer struct {
 	ServiceEntity *reporter.Entity
 	Reporter      reporter.Reporter
 	// 0 not init 1 init
-	initFlag int32
-	Sampler  Sampler
-	Log      *LogWrapper
-	// correlation *CorrelationConfig	// temporarily disable, because haven't been implemented yet
+	initFlag    int32
+	Sampler     Sampler
+	Log         *LogWrapper
+	correlation *CorrelationConfig
 	cdsWatchers []reporter.AgentConfigChangeWatcher
 	// for plugin tools
 	tools *TracerTools
@@ -55,7 +55,7 @@ type Tracer struct {
 }
 
 func (t *Tracer) Init(entity *reporter.Entity, rep reporter.Reporter, samp Sampler, logger operator.LogOperator,
-	meterCollectSecond int) error {
+	meterCollectSecond int, correlation *CorrelationConfig) error {
 	t.ServiceEntity = entity
 	t.Reporter = rep
 	t.Sampler = samp
@@ -65,6 +65,7 @@ func (t *Tracer) Init(entity *reporter.Entity, rep reporter.Reporter, samp Sampl
 	t.Reporter.Boot(entity, t.cdsWatchers)
 	t.initFlag = 1
 	t.initMetricsCollect(meterCollectSecond)
+	t.correlation = correlation
 	// notify the tracer been init success
 	if len(GetInitNotify()) > 0 {
 		for _, fun := range GetInitNotify() {

--- a/plugins/core/tracing.go
+++ b/plugins/core/tracing.go
@@ -175,6 +175,47 @@ func (t *Tracer) CleanContext() {
 	SetGLS(nil)
 }
 
+func (t *Tracer) GetCorrelationContextValue(key string) string {
+	span := t.ActiveSpan()
+	if span == nil {
+		return ""
+	}
+	switch reportedSpan := span.(type) {
+	case *SegmentSpanImpl:
+		return reportedSpan.Context().GetCorrelationContextValue(key)
+	case *RootSegmentSpan:
+		return reportedSpan.Context().GetCorrelationContextValue(key)
+	default:
+		return ""
+	}
+}
+
+func (t *Tracer) SetCorrelationContextValue(key, value string) {
+	span := t.ActiveSpan()
+	if span == nil {
+		return
+	}
+	switch reportedSpan := span.(type) {
+	case *SegmentSpanImpl:
+		if len(value) > t.correlation.MaxValueSize {
+			return
+		}
+		if len(reportedSpan.GetSegmentContext().CorrelationContext) >= t.correlation.MaxKeyCount {
+			return
+		}
+		reportedSpan.Context().SetCorrelationContextValue(key, value)
+	case *RootSegmentSpan:
+		if len(value) > t.correlation.MaxValueSize {
+			return
+		}
+		if len(reportedSpan.GetSegmentContext().CorrelationContext) >= t.correlation.MaxKeyCount {
+			return
+		}
+		reportedSpan.Context().SetCorrelationContextValue(key, value)
+	default:
+	}
+}
+
 type ContextSnapshot struct {
 	activeSpan TracingSpan
 	runtime    *RuntimeContext

--- a/plugins/core/tracing/api.go
+++ b/plugins/core/tracing/api.go
@@ -156,6 +156,23 @@ func copyOptsAsInterface(opts []SpanOption) []interface{} {
 	return optsVal
 }
 
+// GetCorrelationContextValue returns the value of the key in the correlation context.
+func GetCorrelationContextValue(key string) string {
+	op := operator.GetOperator()
+	if op == nil {
+		return ""
+	}
+	return op.Tracing().(operator.TracingOperator).GetCorrelationContextValue(key)
+}
+
+// SetRuntimeContextValue sets the value of the key in the correlation context.
+func SetCorrelationContextValue(key, val string) {
+	op := operator.GetOperator()
+	if op != nil {
+		op.Tracing().(operator.TracingOperator).SetCorrelationContextValue(key, val)
+	}
+}
+
 type extractorWrapperImpl struct {
 	extractor Extractor
 }

--- a/plugins/trace-activation/add_log_intercepter.go
+++ b/plugins/trace-activation/add_log_intercepter.go
@@ -15,21 +15,25 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package operator
+package traceactivation
 
-type TracingOperator interface {
-	CreateEntrySpan(operationName string, extractor interface{}, opts ...interface{}) (s interface{}, err error)
-	CreateLocalSpan(operationName string, opts ...interface{}) (s interface{}, err error)
-	CreateExitSpan(operationName, peer string, injector interface{}, opts ...interface{}) (s interface{}, err error)
-	ActiveSpan() interface{} // to Span
+import (
+	"github.com/apache/skywalking-go/plugins/core/operator"
+	"github.com/apache/skywalking-go/plugins/core/tracing"
+)
 
-	GetRuntimeContextValue(key string) interface{}
-	SetRuntimeContextValue(key string, value interface{})
+type AddLogInterceptor struct {
+}
 
-	CaptureContext() interface{}
-	ContinueContext(interface{})
-	CleanContext()
+func (h *AddLogInterceptor) BeforeInvoke(invocation operator.Invocation) error {
+	span := tracing.ActiveSpan()
+	if span != nil {
+		logs := invocation.Args()[0].([]string)
+		span.Log(logs...)
+	}
+	return nil
+}
 
-	GetCorrelationContextValue(key string) string
-	SetCorrelationContextValue(key, val string)
+func (h *AddLogInterceptor) AfterInvoke(invocation operator.Invocation, result ...interface{}) error {
+	return nil
 }

--- a/plugins/trace-activation/async_finish_intercepter.go
+++ b/plugins/trace-activation/async_finish_intercepter.go
@@ -15,21 +15,24 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package operator
+package traceactivation
 
-type TracingOperator interface {
-	CreateEntrySpan(operationName string, extractor interface{}, opts ...interface{}) (s interface{}, err error)
-	CreateLocalSpan(operationName string, opts ...interface{}) (s interface{}, err error)
-	CreateExitSpan(operationName, peer string, injector interface{}, opts ...interface{}) (s interface{}, err error)
-	ActiveSpan() interface{} // to Span
+import (
+	"github.com/apache/skywalking-go/plugins/core/operator"
+	"github.com/apache/skywalking-go/plugins/core/tracing"
+)
 
-	GetRuntimeContextValue(key string) interface{}
-	SetRuntimeContextValue(key string, value interface{})
+type AsyncFinishInterceptor struct {
+}
 
-	CaptureContext() interface{}
-	ContinueContext(interface{})
-	CleanContext()
+func (h *AsyncFinishInterceptor) BeforeInvoke(invocation operator.Invocation) error {
+	return nil
+}
 
-	GetCorrelationContextValue(key string) string
-	SetCorrelationContextValue(key, val string)
+func (h *AsyncFinishInterceptor) AfterInvoke(invocation operator.Invocation, result ...interface{}) error {
+	span := tracing.ActiveSpan()
+	if span != nil {
+		span.AsyncFinish()
+	}
+	return nil
 }

--- a/plugins/trace-activation/async_prepare_intercepter.go
+++ b/plugins/trace-activation/async_prepare_intercepter.go
@@ -15,21 +15,24 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package operator
+package traceactivation
 
-type TracingOperator interface {
-	CreateEntrySpan(operationName string, extractor interface{}, opts ...interface{}) (s interface{}, err error)
-	CreateLocalSpan(operationName string, opts ...interface{}) (s interface{}, err error)
-	CreateExitSpan(operationName, peer string, injector interface{}, opts ...interface{}) (s interface{}, err error)
-	ActiveSpan() interface{} // to Span
+import (
+	"github.com/apache/skywalking-go/plugins/core/operator"
+	"github.com/apache/skywalking-go/plugins/core/tracing"
+)
 
-	GetRuntimeContextValue(key string) interface{}
-	SetRuntimeContextValue(key string, value interface{})
+type PrepareAsyncInterceptor struct {
+}
 
-	CaptureContext() interface{}
-	ContinueContext(interface{})
-	CleanContext()
+func (h *PrepareAsyncInterceptor) BeforeInvoke(invocation operator.Invocation) error {
+	return nil
+}
 
-	GetCorrelationContextValue(key string) string
-	SetCorrelationContextValue(key, val string)
+func (h *PrepareAsyncInterceptor) AfterInvoke(invocation operator.Invocation, result ...interface{}) error {
+	span := tracing.ActiveSpan()
+	if span != nil {
+		span.PrepareAsync()
+	}
+	return nil
 }

--- a/plugins/trace-activation/capture_intercepter.go
+++ b/plugins/trace-activation/capture_intercepter.go
@@ -15,21 +15,21 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package operator
+package traceactivation
 
-type TracingOperator interface {
-	CreateEntrySpan(operationName string, extractor interface{}, opts ...interface{}) (s interface{}, err error)
-	CreateLocalSpan(operationName string, opts ...interface{}) (s interface{}, err error)
-	CreateExitSpan(operationName, peer string, injector interface{}, opts ...interface{}) (s interface{}, err error)
-	ActiveSpan() interface{} // to Span
+import (
+	"github.com/apache/skywalking-go/plugins/core/operator"
+	"github.com/apache/skywalking-go/plugins/core/tracing"
+)
 
-	GetRuntimeContextValue(key string) interface{}
-	SetRuntimeContextValue(key string, value interface{})
+type CaptureContextInterceptor struct {
+}
 
-	CaptureContext() interface{}
-	ContinueContext(interface{})
-	CleanContext()
+func (h *CaptureContextInterceptor) BeforeInvoke(invocation operator.Invocation) error {
+	invocation.DefineReturnValues(tracing.CaptureContext())
+	return nil
+}
 
-	GetCorrelationContextValue(key string) string
-	SetCorrelationContextValue(key, val string)
+func (h *CaptureContextInterceptor) AfterInvoke(invocation operator.Invocation, result ...interface{}) error {
+	return nil
 }

--- a/plugins/trace-activation/continue_intercepter.go
+++ b/plugins/trace-activation/continue_intercepter.go
@@ -15,21 +15,21 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package operator
+package traceactivation
 
-type TracingOperator interface {
-	CreateEntrySpan(operationName string, extractor interface{}, opts ...interface{}) (s interface{}, err error)
-	CreateLocalSpan(operationName string, opts ...interface{}) (s interface{}, err error)
-	CreateExitSpan(operationName, peer string, injector interface{}, opts ...interface{}) (s interface{}, err error)
-	ActiveSpan() interface{} // to Span
+import (
+	"github.com/apache/skywalking-go/plugins/core/operator"
+	"github.com/apache/skywalking-go/plugins/core/tracing"
+)
 
-	GetRuntimeContextValue(key string) interface{}
-	SetRuntimeContextValue(key string, value interface{})
+type ContinueContextInterceptor struct {
+}
 
-	CaptureContext() interface{}
-	ContinueContext(interface{})
-	CleanContext()
+func (h *ContinueContextInterceptor) BeforeInvoke(invocation operator.Invocation) error {
+	tracing.ContinueContext(invocation.Args()[0].(tracing.ContextSnapshot))
+	return nil
+}
 
-	GetCorrelationContextValue(key string) string
-	SetCorrelationContextValue(key, val string)
+func (h *ContinueContextInterceptor) AfterInvoke(invocation operator.Invocation, result ...interface{}) error {
+	return nil
 }

--- a/plugins/trace-activation/correlation_get_intercepter.go
+++ b/plugins/trace-activation/correlation_get_intercepter.go
@@ -15,21 +15,21 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package operator
+package traceactivation
 
-type TracingOperator interface {
-	CreateEntrySpan(operationName string, extractor interface{}, opts ...interface{}) (s interface{}, err error)
-	CreateLocalSpan(operationName string, opts ...interface{}) (s interface{}, err error)
-	CreateExitSpan(operationName, peer string, injector interface{}, opts ...interface{}) (s interface{}, err error)
-	ActiveSpan() interface{} // to Span
+import (
+	"github.com/apache/skywalking-go/plugins/core/operator"
+	"github.com/apache/skywalking-go/plugins/core/tracing"
+)
 
-	GetRuntimeContextValue(key string) interface{}
-	SetRuntimeContextValue(key string, value interface{})
+type GetCorrelationInterceptor struct {
+}
 
-	CaptureContext() interface{}
-	ContinueContext(interface{})
-	CleanContext()
+func (h *GetCorrelationInterceptor) BeforeInvoke(invocation operator.Invocation) error {
+	invocation.DefineReturnValues(tracing.GetCorrelationContextValue(invocation.Args()[0].(string)))
+	return nil
+}
 
-	GetCorrelationContextValue(key string) string
-	SetCorrelationContextValue(key, val string)
+func (h *GetCorrelationInterceptor) AfterInvoke(invocation operator.Invocation, result ...interface{}) error {
+	return nil
 }

--- a/plugins/trace-activation/correlation_set_intercepter.go
+++ b/plugins/trace-activation/correlation_set_intercepter.go
@@ -15,21 +15,21 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package operator
+package traceactivation
 
-type TracingOperator interface {
-	CreateEntrySpan(operationName string, extractor interface{}, opts ...interface{}) (s interface{}, err error)
-	CreateLocalSpan(operationName string, opts ...interface{}) (s interface{}, err error)
-	CreateExitSpan(operationName, peer string, injector interface{}, opts ...interface{}) (s interface{}, err error)
-	ActiveSpan() interface{} // to Span
+import (
+	"github.com/apache/skywalking-go/plugins/core/operator"
+	"github.com/apache/skywalking-go/plugins/core/tracing"
+)
 
-	GetRuntimeContextValue(key string) interface{}
-	SetRuntimeContextValue(key string, value interface{})
+type SetCorrelationInterceptor struct {
+}
 
-	CaptureContext() interface{}
-	ContinueContext(interface{})
-	CleanContext()
+func (h *SetCorrelationInterceptor) BeforeInvoke(invocation operator.Invocation) error {
+	tracing.SetCorrelationContextValue(invocation.Args()[0].(string), invocation.Args()[1].(string))
+	return nil
+}
 
-	GetCorrelationContextValue(key string) string
-	SetCorrelationContextValue(key, val string)
+func (h *SetCorrelationInterceptor) AfterInvoke(invocation operator.Invocation, result ...interface{}) error {
+	return nil
 }

--- a/plugins/trace-activation/create_entryspan_intercepter.go
+++ b/plugins/trace-activation/create_entryspan_intercepter.go
@@ -15,21 +15,25 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package operator
+package traceactivation
 
-type TracingOperator interface {
-	CreateEntrySpan(operationName string, extractor interface{}, opts ...interface{}) (s interface{}, err error)
-	CreateLocalSpan(operationName string, opts ...interface{}) (s interface{}, err error)
-	CreateExitSpan(operationName, peer string, injector interface{}, opts ...interface{}) (s interface{}, err error)
-	ActiveSpan() interface{} // to Span
+import (
+	"github.com/apache/skywalking-go/plugins/core/operator"
+	"github.com/apache/skywalking-go/plugins/core/tracing"
+	"github.com/apache/skywalking-go/toolkit/trace"
+)
 
-	GetRuntimeContextValue(key string) interface{}
-	SetRuntimeContextValue(key string, value interface{})
+type CreateEntrySpanInterceptor struct {
+}
 
-	CaptureContext() interface{}
-	ContinueContext(interface{})
-	CleanContext()
+func (h *CreateEntrySpanInterceptor) BeforeInvoke(invocation operator.Invocation) error {
+	operationName := invocation.Args()[0].(string)
+	var extractor func(headerKey string) (string, error) = invocation.Args()[1].(trace.ExtractorRef)
+	s, err := tracing.CreateEntrySpan(operationName, extractor)
+	invocation.DefineReturnValues(s, err)
+	return nil
+}
 
-	GetCorrelationContextValue(key string) string
-	SetCorrelationContextValue(key, val string)
+func (h *CreateEntrySpanInterceptor) AfterInvoke(invocation operator.Invocation, result ...interface{}) error {
+	return nil
 }

--- a/plugins/trace-activation/create_localspan_intercepter.go
+++ b/plugins/trace-activation/create_localspan_intercepter.go
@@ -15,21 +15,23 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package operator
+package traceactivation
 
-type TracingOperator interface {
-	CreateEntrySpan(operationName string, extractor interface{}, opts ...interface{}) (s interface{}, err error)
-	CreateLocalSpan(operationName string, opts ...interface{}) (s interface{}, err error)
-	CreateExitSpan(operationName, peer string, injector interface{}, opts ...interface{}) (s interface{}, err error)
-	ActiveSpan() interface{} // to Span
+import (
+	"github.com/apache/skywalking-go/plugins/core/operator"
+	"github.com/apache/skywalking-go/plugins/core/tracing"
+)
 
-	GetRuntimeContextValue(key string) interface{}
-	SetRuntimeContextValue(key string, value interface{})
+type CreateLocalSpanInterceptor struct {
+}
 
-	CaptureContext() interface{}
-	ContinueContext(interface{})
-	CleanContext()
+func (h *CreateLocalSpanInterceptor) BeforeInvoke(invocation operator.Invocation) error {
+	operationName := invocation.Args()[0].(string)
+	s, err := tracing.CreateLocalSpan(operationName)
+	invocation.DefineReturnValues(s, err)
+	return nil
+}
 
-	GetCorrelationContextValue(key string) string
-	SetCorrelationContextValue(key, val string)
+func (h *CreateLocalSpanInterceptor) AfterInvoke(invocation operator.Invocation, result ...interface{}) error {
+	return nil
 }

--- a/plugins/trace-activation/get_segmentid_intercepter.go
+++ b/plugins/trace-activation/get_segmentid_intercepter.go
@@ -15,21 +15,24 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package operator
+package traceactivation
 
-type TracingOperator interface {
-	CreateEntrySpan(operationName string, extractor interface{}, opts ...interface{}) (s interface{}, err error)
-	CreateLocalSpan(operationName string, opts ...interface{}) (s interface{}, err error)
-	CreateExitSpan(operationName, peer string, injector interface{}, opts ...interface{}) (s interface{}, err error)
-	ActiveSpan() interface{} // to Span
+import (
+	"github.com/apache/skywalking-go/plugins/core/operator"
+	"github.com/apache/skywalking-go/plugins/core/tracing"
+)
 
-	GetRuntimeContextValue(key string) interface{}
-	SetRuntimeContextValue(key string, value interface{})
+type GetSegmentIDInterceptor struct {
+}
 
-	CaptureContext() interface{}
-	ContinueContext(interface{})
-	CleanContext()
+func (h *GetSegmentIDInterceptor) BeforeInvoke(invocation operator.Invocation) error {
+	span := tracing.ActiveSpan()
+	if span != nil {
+		invocation.DefineReturnValues(span.TraceSegmentID())
+	}
+	return nil
+}
 
-	GetCorrelationContextValue(key string) string
-	SetCorrelationContextValue(key, val string)
+func (h *GetSegmentIDInterceptor) AfterInvoke(invocation operator.Invocation, result ...interface{}) error {
+	return nil
 }

--- a/plugins/trace-activation/get_spanid_intercepter.go
+++ b/plugins/trace-activation/get_spanid_intercepter.go
@@ -15,21 +15,24 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package operator
+package traceactivation
 
-type TracingOperator interface {
-	CreateEntrySpan(operationName string, extractor interface{}, opts ...interface{}) (s interface{}, err error)
-	CreateLocalSpan(operationName string, opts ...interface{}) (s interface{}, err error)
-	CreateExitSpan(operationName, peer string, injector interface{}, opts ...interface{}) (s interface{}, err error)
-	ActiveSpan() interface{} // to Span
+import (
+	"github.com/apache/skywalking-go/plugins/core/operator"
+	"github.com/apache/skywalking-go/plugins/core/tracing"
+)
 
-	GetRuntimeContextValue(key string) interface{}
-	SetRuntimeContextValue(key string, value interface{})
+type GetSpanIDInterceptor struct {
+}
 
-	CaptureContext() interface{}
-	ContinueContext(interface{})
-	CleanContext()
+func (h *GetSpanIDInterceptor) BeforeInvoke(invocation operator.Invocation) error {
+	span := tracing.ActiveSpan()
+	if span != nil {
+		invocation.DefineReturnValues(span.SpanID())
+	}
+	return nil
+}
 
-	GetCorrelationContextValue(key string) string
-	SetCorrelationContextValue(key, val string)
+func (h *GetSpanIDInterceptor) AfterInvoke(invocation operator.Invocation, result ...interface{}) error {
+	return nil
 }

--- a/plugins/trace-activation/get_traceid_intercepter.go
+++ b/plugins/trace-activation/get_traceid_intercepter.go
@@ -15,21 +15,24 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package operator
+package traceactivation
 
-type TracingOperator interface {
-	CreateEntrySpan(operationName string, extractor interface{}, opts ...interface{}) (s interface{}, err error)
-	CreateLocalSpan(operationName string, opts ...interface{}) (s interface{}, err error)
-	CreateExitSpan(operationName, peer string, injector interface{}, opts ...interface{}) (s interface{}, err error)
-	ActiveSpan() interface{} // to Span
+import (
+	"github.com/apache/skywalking-go/plugins/core/operator"
+	"github.com/apache/skywalking-go/plugins/core/tracing"
+)
 
-	GetRuntimeContextValue(key string) interface{}
-	SetRuntimeContextValue(key string, value interface{})
+type GetTraceIDInterceptor struct {
+}
 
-	CaptureContext() interface{}
-	ContinueContext(interface{})
-	CleanContext()
+func (h *GetTraceIDInterceptor) BeforeInvoke(invocation operator.Invocation) error {
+	span := tracing.ActiveSpan()
+	if span != nil {
+		invocation.DefineReturnValues(span.TraceID())
+	}
+	return nil
+}
 
-	GetCorrelationContextValue(key string) string
-	SetCorrelationContextValue(key, val string)
+func (h *GetTraceIDInterceptor) AfterInvoke(invocation operator.Invocation, result ...interface{}) error {
+	return nil
 }

--- a/plugins/trace-activation/go.mod
+++ b/plugins/trace-activation/go.mod
@@ -1,0 +1,5 @@
+module github.com/apache/skywalking-go/plugin/trace
+
+go 1.18
+
+require github.com/dave/dst v0.27.2 // indirect

--- a/plugins/trace-activation/go.sum
+++ b/plugins/trace-activation/go.sum
@@ -1,0 +1,11 @@
+github.com/apache/skywalking-go/plugins/core v0.0.0-20230911044748-989b03c38669 h1:/sPxTl1S/27CoKcSDZHVH2wGlugQXZ4carG6PMeEOLs=
+github.com/apache/skywalking-go/plugins/core v0.0.0-20230911044748-989b03c38669/go.mod h1:P0tAFNAYJUNsiTlFQgxmCcRcu+7Y0MP8GBZfSI449CM=
+github.com/dave/dst v0.27.2 h1:4Y5VFTkhGLC1oddtNwuxxe36pnyLxMFXT51FOzH8Ekc=
+github.com/dave/dst v0.27.2/go.mod h1:jHh6EOibnHgcUW3WjKHisiooEkYwqpHLBSX1iOBhEyc=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
+golang.org/x/mod v0.9.0 h1:KENHtAZL2y3NLMYZeHY9DW8HW8V+kQyJsY/V9JlKvCs=
+golang.org/x/sys v0.8.0 h1:EBmGv8NaZBZTWvrbjNoL6HVt+IVy3QDQpJs7VRIw3tU=
+golang.org/x/tools v0.7.0 h1:W4OVu8VVOaIO0yzWMNdepAulS7YfoS3Zabrm8DOXXU4=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/plugins/trace-activation/instrument.go
+++ b/plugins/trace-activation/instrument.go
@@ -1,0 +1,136 @@
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Apache Software Foundation (ASF) licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package traceactivation
+
+import (
+	"embed"
+
+	"github.com/apache/skywalking-go/plugins/core/instrument"
+)
+
+//go:embed *
+var fs embed.FS
+
+//skywalking:nocopy
+type Instrument struct {
+}
+
+func NewInstrument() *Instrument {
+	return &Instrument{}
+}
+
+func (i *Instrument) Name() string {
+	return "trace-activation"
+}
+
+func (i *Instrument) BasePackage() string {
+	return "github.com/apache/skywalking-go/toolkit/trace"
+}
+
+func (i *Instrument) VersionChecker(version string) bool {
+	return true
+}
+
+func (i *Instrument) Points() []*instrument.Point {
+	return []*instrument.Point{
+		{
+			PackagePath: "", PackageName: "trace",
+			At:          instrument.NewStaticMethodEnhance("CreateEntrySpan"),
+			Interceptor: "CreateEntrySpanInterceptor",
+		},
+		{
+			PackagePath: "", PackageName: "trace",
+			At:          instrument.NewStaticMethodEnhance("CreateLocalSpan"),
+			Interceptor: "CreateLocalSpanInterceptor",
+		},
+		{
+			PackagePath: "", PackageName: "trace",
+			At:          instrument.NewStaticMethodEnhance("CreateExitSpan"),
+			Interceptor: "CreateExitSpanInterceptor",
+		},
+		{
+			PackagePath: "", PackageName: "trace",
+			At:          instrument.NewStaticMethodEnhance("StopSpan"),
+			Interceptor: "StopSpanInterceptor",
+		},
+		{
+			PackagePath: "", PackageName: "trace",
+			At:          instrument.NewStaticMethodEnhance("CaptureContext"),
+			Interceptor: "CaptureContextInterceptor",
+		},
+		{
+			PackagePath: "", PackageName: "trace",
+			At:          instrument.NewStaticMethodEnhance("ContinueContext"),
+			Interceptor: "ContinueContextInterceptor",
+		},
+		{
+			PackagePath: "", PackageName: "trace",
+			At:          instrument.NewStaticMethodEnhance("GetTraceID"),
+			Interceptor: "GetTraceIDInterceptor",
+		},
+		{
+			PackagePath: "", PackageName: "trace",
+			At:          instrument.NewStaticMethodEnhance("GetSegmentID"),
+			Interceptor: "GetSegmentIDInterceptor",
+		},
+		{
+			PackagePath: "", PackageName: "trace",
+			At:          instrument.NewStaticMethodEnhance("GetSpanID"),
+			Interceptor: "GetSpanIDInterceptor",
+		},
+		{
+			PackagePath: "", PackageName: "trace",
+			At:          instrument.NewStaticMethodEnhance("AddLog"),
+			Interceptor: "AddLogInterceptor",
+		},
+		{
+			PackagePath: "", PackageName: "trace",
+			At:          instrument.NewStaticMethodEnhance("SetTag"),
+			Interceptor: "SetTagInterceptor",
+		},
+		{
+			PackagePath: "", PackageName: "trace",
+			At:          instrument.NewStaticMethodEnhance("SetOperationName"),
+			Interceptor: "SetOperationNameInterceptor",
+		},
+		{
+			PackagePath: "", PackageName: "trace",
+			At:          instrument.NewStaticMethodEnhance("PrepareAsync"),
+			Interceptor: "PrepareAsyncInterceptor",
+		},
+		{
+			PackagePath: "", PackageName: "trace",
+			At:          instrument.NewStaticMethodEnhance("AsyncFinish"),
+			Interceptor: "AsyncFinishInterceptor",
+		},
+		{
+			PackagePath: "", PackageName: "trace",
+			At:          instrument.NewStaticMethodEnhance("GetCorrelation"),
+			Interceptor: "GetCorrelationInterceptor",
+		},
+		{
+			PackagePath: "", PackageName: "trace",
+			At:          instrument.NewStaticMethodEnhance("SetCorrelation"),
+			Interceptor: "SetCorrelationInterceptor",
+		},
+	}
+}
+
+func (i *Instrument) FS() *embed.FS {
+	return &fs
+}

--- a/plugins/trace-activation/set_name_intercepter.go
+++ b/plugins/trace-activation/set_name_intercepter.go
@@ -15,21 +15,24 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package operator
+package traceactivation
 
-type TracingOperator interface {
-	CreateEntrySpan(operationName string, extractor interface{}, opts ...interface{}) (s interface{}, err error)
-	CreateLocalSpan(operationName string, opts ...interface{}) (s interface{}, err error)
-	CreateExitSpan(operationName, peer string, injector interface{}, opts ...interface{}) (s interface{}, err error)
-	ActiveSpan() interface{} // to Span
+import (
+	"github.com/apache/skywalking-go/plugins/core/operator"
+	"github.com/apache/skywalking-go/plugins/core/tracing"
+)
 
-	GetRuntimeContextValue(key string) interface{}
-	SetRuntimeContextValue(key string, value interface{})
+type SetOperationNameInterceptor struct {
+}
 
-	CaptureContext() interface{}
-	ContinueContext(interface{})
-	CleanContext()
+func (h *SetOperationNameInterceptor) BeforeInvoke(invocation operator.Invocation) error {
+	span := tracing.ActiveSpan()
+	if span != nil {
+		span.SetOperationName(invocation.Args()[0].(string))
+	}
+	return nil
+}
 
-	GetCorrelationContextValue(key string) string
-	SetCorrelationContextValue(key, val string)
+func (h *SetOperationNameInterceptor) AfterInvoke(invocation operator.Invocation, result ...interface{}) error {
+	return nil
 }

--- a/plugins/trace-activation/set_tag_intercepter.go
+++ b/plugins/trace-activation/set_tag_intercepter.go
@@ -15,21 +15,24 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package operator
+package traceactivation
 
-type TracingOperator interface {
-	CreateEntrySpan(operationName string, extractor interface{}, opts ...interface{}) (s interface{}, err error)
-	CreateLocalSpan(operationName string, opts ...interface{}) (s interface{}, err error)
-	CreateExitSpan(operationName, peer string, injector interface{}, opts ...interface{}) (s interface{}, err error)
-	ActiveSpan() interface{} // to Span
+import (
+	"github.com/apache/skywalking-go/plugins/core/operator"
+	"github.com/apache/skywalking-go/plugins/core/tracing"
+)
 
-	GetRuntimeContextValue(key string) interface{}
-	SetRuntimeContextValue(key string, value interface{})
+type SetTagInterceptor struct {
+}
 
-	CaptureContext() interface{}
-	ContinueContext(interface{})
-	CleanContext()
+func (h *SetTagInterceptor) BeforeInvoke(invocation operator.Invocation) error {
+	span := tracing.ActiveSpan()
+	if span != nil {
+		span.Tag(invocation.Args()[0].(string), invocation.Args()[1].(string))
+	}
+	return nil
+}
 
-	GetCorrelationContextValue(key string) string
-	SetCorrelationContextValue(key, val string)
+func (h *SetTagInterceptor) AfterInvoke(invocation operator.Invocation, result ...interface{}) error {
+	return nil
 }

--- a/plugins/trace-activation/stopspan_intercepter.go
+++ b/plugins/trace-activation/stopspan_intercepter.go
@@ -15,21 +15,24 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package operator
+package traceactivation
 
-type TracingOperator interface {
-	CreateEntrySpan(operationName string, extractor interface{}, opts ...interface{}) (s interface{}, err error)
-	CreateLocalSpan(operationName string, opts ...interface{}) (s interface{}, err error)
-	CreateExitSpan(operationName, peer string, injector interface{}, opts ...interface{}) (s interface{}, err error)
-	ActiveSpan() interface{} // to Span
+import (
+	"github.com/apache/skywalking-go/plugins/core/operator"
+	"github.com/apache/skywalking-go/plugins/core/tracing"
+)
 
-	GetRuntimeContextValue(key string) interface{}
-	SetRuntimeContextValue(key string, value interface{})
+type StopSpanInterceptor struct {
+}
 
-	CaptureContext() interface{}
-	ContinueContext(interface{})
-	CleanContext()
+func (h *StopSpanInterceptor) BeforeInvoke(invocation operator.Invocation) error {
+	span := tracing.ActiveSpan()
+	if span != nil {
+		span.End()
+	}
+	return nil
+}
 
-	GetCorrelationContextValue(key string) string
-	SetCorrelationContextValue(key, val string)
+func (h *StopSpanInterceptor) AfterInvoke(invocation operator.Invocation, result ...interface{}) error {
+	return nil
 }

--- a/test/plugins/runner-helper/context.go
+++ b/test/plugins/runner-helper/context.go
@@ -83,6 +83,7 @@ type Config struct {
 	ExportPort     int                                 `yaml:"export-port"`
 	SupportVersion []SupportVersion                    `yaml:"support-version"`
 	Dependencies   map[string]*DockerDependencyService `yaml:"dependencies"`
+	Toolkit        bool                                `yaml:"toolkit"`
 }
 
 type DockerDependencyService struct {

--- a/test/plugins/runner-helper/templates/dockerfile.tpl
+++ b/test/plugins/runner-helper/templates/dockerfile.tpl
@@ -29,6 +29,9 @@ RUN echo "replace github.com/apache/skywalking-go => ../../../../../" >> test/pl
 {{ end -}}
 
 WORKDIR /skywalking-go/test/plugins/workspace/{{.Context.ScenarioName}}/{{.Context.CaseName}}/
+{{ if .Context.Config.Toolkit -}}
+RUN echo "replace github.com/apache/skywalking-go/toolkit => ../../../../../toolkit" >> ./go.mod
+{{ end }}
 RUN go mod tidy
 
 ENV GO_BUILD_OPTS=" -toolexec \"/skywalking-go{{.ToolExecPath}}\" -a -work "

--- a/test/plugins/scenarios/trace-activation/bin/startup.sh
+++ b/test/plugins/scenarios/trace-activation/bin/startup.sh
@@ -1,0 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+home="$(cd "$(dirname $0)"; pwd)"
+go build ${GO_BUILD_OPTS} -o trace-activation
+
+./trace-activation

--- a/test/plugins/scenarios/trace-activation/config/excepted.yml
+++ b/test/plugins/scenarios/trace-activation/config/excepted.yml
@@ -1,0 +1,210 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+segmentItems:
+  - serviceName: trace-activation
+    segmentSize: 3
+    segments:
+      - segmentId: not null
+        spans:
+          - operationName: GET:/health
+            parentSpanId: -1
+            spanId: 0
+            spanLayer: Http
+            startTime: nq 0
+            endTime: nq 0
+            componentId: 5004
+            isError: false
+            spanType: Entry
+            peer: ''
+            skipAnalysis: false
+            tags:
+              - {key: http.method, value: GET}
+              - {key: url, value: 'service:8080/health'}
+              - {key: status_code, value: '200'}
+      - segmentId: not null
+        spans:
+          - operationName: testSetCorrelation
+            parentSpanId: 0
+            spanId: 1
+            spanLayer: Unknown
+            startTime: nq 0
+            endTime: nq 0
+            componentId: 0
+            isError: false
+            spanType: Local
+            peer: ''
+            skipAnalysis: false
+            tags:
+              - {key: testCorrelation, value: success}
+          - operationName: GET:/provider
+            parentSpanId: -1
+            spanId: 0
+            spanLayer: Http
+            startTime: nq 0
+            endTime: nq 0
+            componentId: 5004
+            isError: false
+            spanType: Entry
+            peer: ''
+            skipAnalysis: false
+            tags:
+              - {key: http.method, value: GET}
+              - {key: url, value: 'localhost:8080/provider'}
+              - {key: status_code, value: '200'}
+            refs:
+              - {parentEndpoint: 'GET:/consumer', networkAddress: 'localhost:8080', refType: CrossProcess,
+                 parentSpanId: 7, parentTraceSegmentId: not null,
+                 parentServiceInstance: not null, parentService: trace-activation,
+                 traceId: not null}
+      - segmentId: not null
+        spans:
+          - operationName: testSetTag
+            parentSpanId: 0
+            spanId: 1
+            spanLayer: Unknown
+            startTime: nq 0
+            endTime: nq 0
+            componentId: 0
+            isError: false
+            spanType: Local
+            peer: ''
+            skipAnalysis: false
+            tags:
+              - {key: SetTag, value: success}
+          - operationName: testAddLog
+            parentSpanId: 0
+            spanId: 2
+            spanLayer: Unknown
+            startTime: nq 0
+            endTime: nq 0
+            componentId: 0
+            isError: false
+            spanType: Local
+            peer: ''
+            skipAnalysis: false
+            logs:
+              - logEvent:
+                  - { key: AddLog, value: success }
+          - operationName: testGetSegmentID
+            parentSpanId: 0
+            spanId: 3
+            spanLayer: Unknown
+            startTime: nq 0
+            endTime: nq 0
+            componentId: 0
+            isError: false
+            spanType: Local
+            peer: ''
+            skipAnalysis: false
+            tags:
+              - { key: segmentID, value: not null }
+          - operationName: testGetSpanID
+            parentSpanId: 0
+            spanId: 4
+            spanLayer: Unknown
+            startTime: nq 0
+            endTime: nq 0
+            componentId: 0
+            isError: false
+            spanType: Local
+            peer: ''
+            skipAnalysis: false
+            tags:
+              - {key: spanID, value: '4'}
+          - operationName: testGetTraceID
+            parentSpanId: 0
+            spanId: 5
+            spanLayer: Unknown
+            startTime: nq 0
+            endTime: nq 0
+            componentId: 0
+            isError: false
+            spanType: Local
+            peer: ''
+            skipAnalysis: false
+            tags:
+              - {key: traceID, value: not null}
+          - {operationName: testSetOperationName_success, parentSpanId: 0, spanId: 6, spanLayer: Unknown,
+             startTime: nq 0, endTime: nq 0, componentId: 0, isError: false,
+             spanType: Local, peer: '', skipAnalysis: false}
+          - operationName: testContinueContext
+            parentSpanId: 8
+            spanId: 9
+            spanLayer: Unknown
+            startTime: nq 0
+            endTime: nq 0
+            componentId: 0
+            isError: false
+            spanType: Local
+            peer: ''
+            skipAnalysis: false
+            tags:
+              - {key: testContinueContext, value: success}
+          - operationName: GET:/provider
+            parentSpanId: 0
+            spanId: 7
+            spanLayer: Http
+            startTime: nq 0
+            endTime: nq 0
+            componentId: 5005
+            isError: false
+            spanType: Exit
+            peer: localhost:8080
+            skipAnalysis: false
+            tags:
+              - {key: http.method, value: GET}
+              - {key: url, value: 'localhost:8080/provider'}
+              - {key: status_code, value: '200'}
+          - {operationName: testCaptureContext, parentSpanId: 0, spanId: 8, spanLayer: Unknown,
+             startTime: nq 0, endTime: nq 0, componentId: 0, isError: false,
+             spanType: Local, peer: '', skipAnalysis: false}
+          - {operationName: ExitSpan, parentSpanId: 8, spanId: 10, spanLayer: Unknown, startTime: nq 0,
+             endTime: nq 0, componentId: 0, isError: false, spanType: Exit, peer: localhost,
+             skipAnalysis: false}
+          - operationName: EntrySpan
+            parentSpanId: 10
+            spanId: 11
+            spanLayer: Unknown
+            startTime: nq 0
+            endTime: nq 0
+            componentId: 0
+            isError: false
+            spanType: Entry
+            peer: ''
+            skipAnalysis: false
+            refs:
+              - {parentEndpoint: 'GET:/consumer', networkAddress: localhost, refType: CrossProcess,
+                 parentSpanId: 10, parentTraceSegmentId: not null,
+                 parentServiceInstance: not null, parentService: trace-activation,
+                 traceId: not null}
+          - operationName: GET:/consumer
+            parentSpanId: -1
+            spanId: 0
+            spanLayer: Http
+            startTime: nq 0
+            endTime: nq 0
+            componentId: 5004
+            isError: false
+            spanType: Entry
+            peer: ''
+            skipAnalysis: false
+            tags:
+              - {key: http.method, value: GET}
+              - {key: url, value: 'service:8080/consumer'}
+              - {key: status_code, value: '200'}
+meterItems: []
+logItems: []

--- a/test/plugins/scenarios/trace-activation/go.mod
+++ b/test/plugins/scenarios/trace-activation/go.mod
@@ -1,0 +1,4 @@
+module test/plugins/scenarios/trace-activation
+
+go 1.18
+

--- a/test/plugins/scenarios/trace-activation/main.go
+++ b/test/plugins/scenarios/trace-activation/main.go
@@ -1,0 +1,55 @@
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Apache Software Foundation (ASF) licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package main
+
+import (
+	"net/http"
+
+	_ "github.com/apache/skywalking-go"
+	"github.com/apache/skywalking-go/toolkit/trace"
+)
+
+func providerHandler(w http.ResponseWriter, r *http.Request) {
+	trace.CreateLocalSpan("testSetCorrelation")
+	trace.SetTag("testCorrelation", trace.GetCorrelation("testCorrelation"))
+	trace.StopSpan()
+}
+
+func consumerHandler(w http.ResponseWriter, r *http.Request) {
+	testTag()
+	testLog()
+	testGetSegmentID()
+	testGetSpanID()
+	testGetTraceID()
+	testSetOperationName()
+	testCorrelation()
+	testContext()
+	testContextCarrier()
+}
+
+func main() {
+	http.HandleFunc("/provider", providerHandler)
+
+	http.HandleFunc("/consumer", consumerHandler)
+
+	http.HandleFunc("/health", func(writer http.ResponseWriter, request *http.Request) {
+		writer.WriteHeader(http.StatusOK)
+	})
+
+	_ = http.ListenAndServe(":8080", nil)
+}

--- a/test/plugins/scenarios/trace-activation/plugin.yml
+++ b/test/plugins/scenarios/trace-activation/plugin.yml
@@ -1,0 +1,26 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+entry-service: http://${HTTP_HOST}:${HTTP_PORT}/consumer
+health-checker: http://${HTTP_HOST}:${HTTP_PORT}/health
+start-script: ./bin/startup.sh
+framework: go
+export-port: 8080
+support-version:
+  - go: 1.18
+  - go: 1.19
+  - go: 1.20
+toolkit: true

--- a/test/plugins/scenarios/trace-activation/test_service.go
+++ b/test/plugins/scenarios/trace-activation/test_service.go
@@ -1,0 +1,99 @@
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Apache Software Foundation (ASF) licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package main
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/apache/skywalking-go/toolkit/trace"
+)
+
+func testTag() {
+	trace.CreateLocalSpan("testSetTag")
+	trace.SetTag("SetTag", "success")
+	trace.StopSpan()
+}
+
+func testLog() {
+	trace.CreateLocalSpan("testAddLog")
+	trace.AddLog("AddLog", "success")
+	trace.StopSpan()
+}
+
+func testSetOperationName() {
+	trace.CreateLocalSpan("testSetOperationName_failed")
+	trace.SetOperationName("testSetOperationName_success")
+	trace.StopSpan()
+}
+
+func testGetTraceID() {
+	trace.CreateLocalSpan("testGetTraceID")
+	trace.SetTag("traceID", trace.GetTraceID())
+	trace.StopSpan()
+}
+
+func testGetSpanID() {
+	trace.CreateLocalSpan("testGetSpanID")
+	trace.SetTag("spanID", strconv.FormatInt(int64(trace.GetSpanID()), 10))
+	trace.StopSpan()
+}
+
+func testGetSegmentID() {
+	trace.CreateLocalSpan("testGetSegmentID")
+	trace.SetTag("segmentID", trace.GetSegmentID())
+	trace.StopSpan()
+}
+
+func testContext() {
+	trace.CreateLocalSpan("testCaptureContext")
+	captureSpanID := trace.GetSpanID()
+	ctx := trace.CaptureContext()
+	trace.StopSpan()
+
+	trace.ContinueContext(ctx)
+	continueSpanID := trace.GetSpanID()
+	trace.CreateLocalSpan("testContinueContext")
+	if captureSpanID == continueSpanID {
+		trace.SetTag("testContinueContext", "success")
+	}
+	trace.StopSpan()
+}
+
+func testContextCarrier() {
+	request, _ := http.NewRequest("GET", "http://localhost/", http.NoBody)
+	trace.CreateExitSpan("ExitSpan", request.Host, func(headerKey, headerValue string) error {
+		request.Header.Add(headerKey, headerValue)
+		return nil
+	})
+
+	trace.CreateEntrySpan("EntrySpan", func(headerKey string) (string, error) {
+		return request.Header.Get(headerKey), nil
+	})
+	trace.StopSpan()
+
+	trace.StopSpan()
+}
+
+func testCorrelation() {
+	trace.SetCorrelation("testCorrelation", "success")
+	_, err := http.Get("http://localhost:8080/provider")
+	if err != nil {
+		return
+	}
+}

--- a/toolkit/go.mod
+++ b/toolkit/go.mod
@@ -1,0 +1,3 @@
+module github.com/apache/skywalking-go/toolkit
+
+go 1.18

--- a/toolkit/trace/api.go
+++ b/toolkit/trace/api.go
@@ -1,0 +1,77 @@
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Apache Software Foundation (ASF) licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package trace
+
+func CreateEntrySpan(operationName string, extractor ExtractorRef) (s SpanRef, err error) {
+	return nil, err
+}
+
+// nolint
+func CreateExitSpan(operationName string, peer string, injector InjectorRef) (s SpanRef, err error) {
+	return nil, err
+}
+
+func CreateLocalSpan(operationName string) (s SpanRef, err error) {
+	return nil, err
+}
+
+func StopSpan() {
+}
+
+func CaptureContext() ContextSnapshotRef {
+	return nil
+}
+
+func ContinueContext(ctx ContextSnapshotRef) {
+}
+
+func SetOperationName(string) {
+}
+
+func GetTraceID() string {
+	return ""
+}
+
+func GetSegmentID() string {
+	return ""
+}
+
+func GetSpanID() int32 {
+	return -1
+}
+
+// nolint
+func SetTag(key string, value string) {
+}
+
+func AddLog(...string) {
+}
+
+func PrepareAsync() {
+}
+
+func AsyncFinish() {
+}
+
+func GetCorrelation(key string) string {
+	return ""
+}
+
+// nolint
+func SetCorrelation(key string, value string) {
+}

--- a/toolkit/trace/context.go
+++ b/toolkit/trace/context.go
@@ -15,21 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package operator
+package trace
 
-type TracingOperator interface {
-	CreateEntrySpan(operationName string, extractor interface{}, opts ...interface{}) (s interface{}, err error)
-	CreateLocalSpan(operationName string, opts ...interface{}) (s interface{}, err error)
-	CreateExitSpan(operationName, peer string, injector interface{}, opts ...interface{}) (s interface{}, err error)
-	ActiveSpan() interface{} // to Span
-
-	GetRuntimeContextValue(key string) interface{}
-	SetRuntimeContextValue(key string, value interface{})
-
-	CaptureContext() interface{}
-	ContinueContext(interface{})
-	CleanContext()
-
-	GetCorrelationContextValue(key string) string
-	SetCorrelationContextValue(key, val string)
+type ContextSnapshotRef interface {
 }

--- a/toolkit/trace/span.go
+++ b/toolkit/trace/span.go
@@ -15,21 +15,11 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package operator
+package trace
 
-type TracingOperator interface {
-	CreateEntrySpan(operationName string, extractor interface{}, opts ...interface{}) (s interface{}, err error)
-	CreateLocalSpan(operationName string, opts ...interface{}) (s interface{}, err error)
-	CreateExitSpan(operationName, peer string, injector interface{}, opts ...interface{}) (s interface{}, err error)
-	ActiveSpan() interface{} // to Span
+type ExtractorRef func(headerKey string) (string, error)
 
-	GetRuntimeContextValue(key string) interface{}
-	SetRuntimeContextValue(key string, value interface{})
+type InjectorRef func(headerKey, headerValue string) error
 
-	CaptureContext() interface{}
-	ContinueContext(interface{})
-	CleanContext()
-
-	GetCorrelationContextValue(key string) string
-	SetCorrelationContextValue(key, val string)
+type SpanRef interface {
 }

--- a/tools/go-agent/config/agent.default.yaml
+++ b/tools/go-agent/config/agent.default.yaml
@@ -27,6 +27,9 @@ agent:
   meter:
     # The interval of collecting metrics, in seconds.
     collect_interval: ${SW_AGENT_METER_COLLECT_INTERVAL:20}
+  correlation:
+    max_key_count: ${SW_AGENT_CORRELATION_MAX_KEY_COUNT:3}
+    max_value_size: ${SW_AGENT_CORRELATION_MAX_VALUE_SIZE:128}
 
 reporter:
   grpc:

--- a/tools/go-agent/config/loader.go
+++ b/tools/go-agent/config/loader.go
@@ -49,6 +49,7 @@ type Agent struct {
 	InstanceEnvName StringValue `yaml:"instance_env_name"`
 	Sampler         StringValue `yaml:"sampler"`
 	Meter           Meter       `yaml:"meter"`
+	Correlation     Correlation `yaml:"correlation"`
 }
 
 type Reporter struct {
@@ -95,6 +96,11 @@ type GRPCReporterTLS struct {
 type Plugin struct {
 	Config   PluginConfig `yaml:"config"`
 	Excluded StringValue  `yaml:"excluded"`
+}
+
+type Correlation struct {
+	MaxKeyCount  StringValue `yaml:"max_key_count"`
+	MaxValueSize StringValue `yaml:"max_value_size"`
 }
 
 func LoadConfig(path string) error {

--- a/tools/go-agent/instrument/agentcore/instrument.go
+++ b/tools/go-agent/instrument/agentcore/instrument.go
@@ -158,7 +158,11 @@ func (t *Tracer) InitTracer(extend map[string]interface{}) {
 			logger = l
 		}
 	}
-	if err := t.Init(entity, rep, samp, logger, meterCollectInterval); err != nil {
+	correlation := &CorrelationConfig{
+		MaxKeyCount : {{.Config.Agent.Correlation.MaxKeyCount.ToGoIntValue "loading the agent correlation maxKeyCount error"}},
+		MaxValueSize : {{.Config.Agent.Correlation.MaxValueSize.ToGoIntValue "loading the agent correlation maxValueSize error"}},
+	}
+	if err := t.Init(entity, rep, samp, logger, meterCollectInterval, correlation); err != nil {
 		t.Log.Errorf("cannot initialize the SkyWalking Tracer: %v", err)
 	}
 }`, struct {

--- a/tools/go-agent/instrument/plugins/instrument.go
+++ b/tools/go-agent/instrument/plugins/instrument.go
@@ -107,8 +107,9 @@ func (i *Instrument) CouldHandle(opts *api.CompileOptions) bool {
 		// check the version of the framework could handler
 		version, err := i.tryToFindThePluginVersion(opts, ins)
 		if err != nil {
-			logrus.Warnf("ignore the plugin %s, because: %s", ins.Name(), err)
-			continue
+			// Local package (e.g. replaced toolkit) does not have version.
+			// So when the version is not detected, we should not skip it.
+			logrus.Warnf("the plugin %s %s", ins.Name(), err)
 		}
 
 		if ins.VersionChecker(version) {
@@ -340,7 +341,7 @@ func (i *Instrument) processPluginConfig(fileContent []byte) error {
 	return nil
 }
 
-//nolint
+// nolint
 func (i *Instrument) copyOperatorsFS(context *rewrite.Context, baseDir, packageName string) ([]string, error) {
 	result := make([]string, 0)
 	var debugBaseDir string

--- a/tools/go-agent/instrument/plugins/register.go
+++ b/tools/go-agent/instrument/plugins/register.go
@@ -18,6 +18,7 @@
 package plugins
 
 import (
+	traceactivation "github.com/apache/skywalking-go/plugin/trace"
 	"github.com/apache/skywalking-go/plugins/core/instrument"
 	"github.com/apache/skywalking-go/plugins/dubbo"
 	"github.com/apache/skywalking-go/plugins/gin"
@@ -53,6 +54,7 @@ func init() {
 	registerFramework(mux.NewInstrument())
 	registerFramework(grpc.NewInstrument())
 	registerFramework(irisv12.NewInstrument())
+	registerFramework(traceactivation.NewInstrument())
 
 	// gorm related instruments
 	registerFramework(gorm_entry.NewInstrument())


### PR DESCRIPTION
# Add
- Provide APIs to users
- support get/set correlation context value
- Add documents related these APIs.
- Add tests for toolkit
- Add the `toolkit` option in config.
Due to the interception of packages by skywalking-go, it defaults to fetching them remotely (using `go mod tidy`). However, during testing, `toolkit` only exists locally, so `go mod tidy` will be unable to fetch the remote package for `toolkit`. Therefore, I added a `toolkit` field in the config file. If this field is determined to be true, the package path will be changed to the local one using `replace`, avoiding the download and error reported by `go mod tidy`.

realted to apache/skywalking#11333 