### PR TITLE
feat: update Makefile to support build arm64 platform

### DIFF
--- a/tools/go-agent/Makefile
+++ b/tools/go-agent/Makefile
@@ -34,7 +34,7 @@ GO_GET = $(GO) get
 
 PLATFORMS := linux darwin windows
 os = $(word 1, $@)
-ARCH = amd64
+ARCH ?= amd64
 
 SHELL = /bin/bash
 


### PR DESCRIPTION
I wan't to build skywalking-go agent on arm64 platform, but I found that Makefile defines ARCH=amd64 with dead code, so I update the Makefile, that I can compile arm64 platform with:
```
make build ARCH=arm64
```