### PR TITLE
fix: panic happens when reporter init failed

### DIFF
--- a/plugins/core/reporter/api.go
+++ b/plugins/core/reporter/api.go
@@ -91,10 +91,16 @@ type Entity struct {
 }
 
 func (e *Entity) GetServiceName() string {
+	if e == nil {
+		return ""
+	}
 	return e.ServiceName
 }
 
 func (e *Entity) GetInstanceName() string {
+	if e == nil {
+		return ""
+	}
 	return e.ServiceInstanceName
 }
 


### PR DESCRIPTION
I implemented a reporter to send span segments to Kafka， but I got panic when kafka cannot connect. I noticed the root cause is following code:
```go
// tools/go-agent/instrument/logger/context.go
entity := operator.Entity()
if entity != nil {
	if e, ok := entity.(Entity); ok && e != nil {
		serviceName, instanceName = e.GetServiceName(), e.GetInstanceName()
	}
}
```

When reporter init failed, entity point to `(*reporter.Entity)(nil)`, `(*reporter.Entity)(nil)` not equals to `nil`， so  if condition will go in, and program panic when `e.GetServiceName()` called.

I have no idea whether this happens when grpc dail serveraddr failed, but I think it's necessary to make the code more robust.