### PR TITLE
Fix url about toolkit-trace documentation

### DIFF
--- a/docs/menu.yml
+++ b/docs/menu.yml
@@ -45,7 +45,7 @@ catalog:
         - name: Manual APIs
           catalog:
             - name: Tracing APIs
-              path: /en/advanced-features/manual-apis/toolkit-trace.md
+              path: /en/advanced-features/manual-apis/toolkit-trace
     - name: Plugins
       catalog:
         - name: Supported Libraries


### PR DESCRIPTION
Fix problem：https://github.com/apache/skywalking-go/pull/104#issuecomment-1770349895
### Change
- Remove the suffix from the path of toolkit-trace documentation