### PR TITLE
fix: users can not use async api in toolkit-trace

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@ Release Notes.
 #### Documentation
 
 #### Bug Fixes
+* Fix users can not use async api in toolkit-trace 
 
 #### Issues and PR
 - All issues are [here](https://github.com/apache/skywalking/milestone/197?closed=1)

--- a/docs/en/advanced-features/manual-apis/toolkit-trace.md
+++ b/docs/en/advanced-features/manual-apis/toolkit-trace.md
@@ -99,7 +99,12 @@ The Component ID in Span is used to identify the current component, which is dec
 
 ### Async Prepare/Finish
 
-Use `trace.PrepareAsync()` to make current span still alive until `trace.AsyncFinish()` called.
+`SpanRef` is the return value of `CreateSpan`.Use `SpanRef.PrepareAsync()` to make current span still alive until `SpanRef.AsyncFinish()` called.
+
+* Call `PrepareAsync()`.
+* Use `trace.StopSpan()` to stop span in the original goroutine.
+* Propagate the `SpanRef` to any other goroutine. 
+* Call `SpanRef.AsyncFinish()` in any goroutine.
 
 ### Capture/Continue Context Snapshot
 

--- a/plugins/trace-activation/async_finish_intercepter.go
+++ b/plugins/trace-activation/async_finish_intercepter.go
@@ -30,9 +30,12 @@ func (h *AsyncFinishInterceptor) BeforeInvoke(invocation operator.Invocation) er
 }
 
 func (h *AsyncFinishInterceptor) AfterInvoke(invocation operator.Invocation, result ...interface{}) error {
-	span := tracing.ActiveSpan()
-	if span != nil {
-		span.AsyncFinish()
+	enhancced, ok := invocation.CallerInstance().(operator.EnhancedInstance)
+	if !ok {
+		return nil
 	}
+	s := enhancced.GetSkyWalkingDynamicField().(tracing.Span)
+	s.AsyncFinish()
+	enhancced.SetSkyWalkingDynamicField(s)
 	return nil
 }

--- a/plugins/trace-activation/async_log_intercepter.go
+++ b/plugins/trace-activation/async_log_intercepter.go
@@ -15,7 +15,28 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package trace
+package traceactivation
 
-type ContextSnapshotRef interface {
+import (
+	"github.com/apache/skywalking-go/plugins/core/operator"
+	"github.com/apache/skywalking-go/plugins/core/tracing"
+)
+
+type AsyncLogInterceptor struct {
+}
+
+func (h *AsyncLogInterceptor) BeforeInvoke(invocation operator.Invocation) error {
+	return nil
+}
+
+func (h *AsyncLogInterceptor) AfterInvoke(invocation operator.Invocation, result ...interface{}) error {
+	enhancced, ok := invocation.CallerInstance().(operator.EnhancedInstance)
+	if !ok {
+		return nil
+	}
+	s := enhancced.GetSkyWalkingDynamicField().(tracing.Span)
+	logs := invocation.Args()[0].([]string)
+	s.Log(logs...)
+	enhancced.SetSkyWalkingDynamicField(s)
+	return nil
 }

--- a/plugins/trace-activation/async_tag_intercepter.go
+++ b/plugins/trace-activation/async_tag_intercepter.go
@@ -22,20 +22,20 @@ import (
 	"github.com/apache/skywalking-go/plugins/core/tracing"
 )
 
-type PrepareAsyncInterceptor struct {
+type AsyncTagInterceptor struct {
 }
 
-func (h *PrepareAsyncInterceptor) BeforeInvoke(invocation operator.Invocation) error {
+func (h *AsyncTagInterceptor) BeforeInvoke(invocation operator.Invocation) error {
 	return nil
 }
 
-func (h *PrepareAsyncInterceptor) AfterInvoke(invocation operator.Invocation, result ...interface{}) error {
+func (h *AsyncTagInterceptor) AfterInvoke(invocation operator.Invocation, result ...interface{}) error {
 	enhancced, ok := invocation.CallerInstance().(operator.EnhancedInstance)
 	if !ok {
 		return nil
 	}
 	s := enhancced.GetSkyWalkingDynamicField().(tracing.Span)
-	s.PrepareAsync()
+	s.Tag(invocation.Args()[0].(string), invocation.Args()[1].(string))
 	enhancced.SetSkyWalkingDynamicField(s)
 	return nil
 }

--- a/plugins/trace-activation/create_entryspan_intercepter.go
+++ b/plugins/trace-activation/create_entryspan_intercepter.go
@@ -27,13 +27,20 @@ type CreateEntrySpanInterceptor struct {
 }
 
 func (h *CreateEntrySpanInterceptor) BeforeInvoke(invocation operator.Invocation) error {
-	operationName := invocation.Args()[0].(string)
-	var extractor func(headerKey string) (string, error) = invocation.Args()[1].(trace.ExtractorRef)
-	s, err := tracing.CreateEntrySpan(operationName, extractor)
-	invocation.DefineReturnValues(s, err)
 	return nil
 }
 
 func (h *CreateEntrySpanInterceptor) AfterInvoke(invocation operator.Invocation, result ...interface{}) error {
+	operationName := invocation.Args()[0].(string)
+	var extractor func(headerKey string) (string, error) = invocation.Args()[1].(trace.ExtractorRef)
+	s, err := tracing.CreateEntrySpan(operationName, extractor)
+	if err != nil {
+		return nil
+	}
+	enhancced, ok := result[0].(operator.EnhancedInstance)
+	if !ok {
+		return nil
+	}
+	enhancced.SetSkyWalkingDynamicField(s)
 	return nil
 }

--- a/plugins/trace-activation/create_entryspan_intercepter.go
+++ b/plugins/trace-activation/create_entryspan_intercepter.go
@@ -36,6 +36,7 @@ func (h *CreateEntrySpanInterceptor) AfterInvoke(invocation operator.Invocation,
 	s, err := tracing.CreateEntrySpan(operationName, extractor)
 	if err != nil {
 		invocation.DefineReturnValues(nil, err)
+		return nil
 	}
 	enhancced, ok := result[0].(operator.EnhancedInstance)
 	if !ok {

--- a/plugins/trace-activation/create_entryspan_intercepter.go
+++ b/plugins/trace-activation/create_entryspan_intercepter.go
@@ -35,7 +35,7 @@ func (h *CreateEntrySpanInterceptor) AfterInvoke(invocation operator.Invocation,
 	var extractor func(headerKey string) (string, error) = invocation.Args()[1].(trace.ExtractorRef)
 	s, err := tracing.CreateEntrySpan(operationName, extractor)
 	if err != nil {
-		return nil
+		invocation.DefineReturnValues(nil, err)
 	}
 	enhancced, ok := result[0].(operator.EnhancedInstance)
 	if !ok {

--- a/plugins/trace-activation/create_exitspan_intercepter.go
+++ b/plugins/trace-activation/create_exitspan_intercepter.go
@@ -37,6 +37,7 @@ func (h *CreateExitSpanInterceptor) AfterInvoke(invocation operator.Invocation, 
 	s, err := tracing.CreateExitSpan(operationName, peer, injector)
 	if err != nil {
 		invocation.DefineReturnValues(nil, err)
+		return nil
 	}
 	enhancced, ok := result[0].(operator.EnhancedInstance)
 	if !ok {

--- a/plugins/trace-activation/create_exitspan_intercepter.go
+++ b/plugins/trace-activation/create_exitspan_intercepter.go
@@ -36,7 +36,7 @@ func (h *CreateExitSpanInterceptor) AfterInvoke(invocation operator.Invocation, 
 	var injector func(headerKey, headerValue string) error = invocation.Args()[2].(trace.InjectorRef)
 	s, err := tracing.CreateExitSpan(operationName, peer, injector)
 	if err != nil {
-		return nil
+		invocation.DefineReturnValues(nil, err)
 	}
 	enhancced, ok := result[0].(operator.EnhancedInstance)
 	if !ok {

--- a/plugins/trace-activation/create_exitspan_intercepter.go
+++ b/plugins/trace-activation/create_exitspan_intercepter.go
@@ -27,14 +27,21 @@ type CreateExitSpanInterceptor struct {
 }
 
 func (h *CreateExitSpanInterceptor) BeforeInvoke(invocation operator.Invocation) error {
-	operationName := invocation.Args()[0].(string)
-	peer := invocation.Args()[1].(string)
-	var injector func(headerKey, headerValue string) error = invocation.Args()[2].(trace.InjectorRef)
-	s, err := tracing.CreateExitSpan(operationName, peer, injector)
-	invocation.DefineReturnValues(s, err)
 	return nil
 }
 
 func (h *CreateExitSpanInterceptor) AfterInvoke(invocation operator.Invocation, result ...interface{}) error {
+	operationName := invocation.Args()[0].(string)
+	peer := invocation.Args()[1].(string)
+	var injector func(headerKey, headerValue string) error = invocation.Args()[2].(trace.InjectorRef)
+	s, err := tracing.CreateExitSpan(operationName, peer, injector)
+	if err != nil {
+		return nil
+	}
+	enhancced, ok := result[0].(operator.EnhancedInstance)
+	if !ok {
+		return nil
+	}
+	enhancced.SetSkyWalkingDynamicField(s)
 	return nil
 }

--- a/plugins/trace-activation/create_localspan_intercepter.go
+++ b/plugins/trace-activation/create_localspan_intercepter.go
@@ -34,6 +34,7 @@ func (h *CreateLocalSpanInterceptor) AfterInvoke(invocation operator.Invocation,
 	s, err := tracing.CreateLocalSpan(operationName)
 	if err != nil {
 		invocation.DefineReturnValues(nil, err)
+		return nil
 	}
 	enhancced, ok := result[0].(operator.EnhancedInstance)
 	if !ok {

--- a/plugins/trace-activation/create_localspan_intercepter.go
+++ b/plugins/trace-activation/create_localspan_intercepter.go
@@ -31,7 +31,10 @@ func (h *CreateLocalSpanInterceptor) BeforeInvoke(invocation operator.Invocation
 
 func (h *CreateLocalSpanInterceptor) AfterInvoke(invocation operator.Invocation, result ...interface{}) error {
 	operationName := invocation.Args()[0].(string)
-	s, _ := tracing.CreateLocalSpan(operationName)
+	s, err := tracing.CreateLocalSpan(operationName)
+	if err != nil {
+		invocation.DefineReturnValues(nil, err)
+	}
 	enhancced, ok := result[0].(operator.EnhancedInstance)
 	if !ok {
 		return nil

--- a/plugins/trace-activation/create_localspan_intercepter.go
+++ b/plugins/trace-activation/create_localspan_intercepter.go
@@ -26,12 +26,16 @@ type CreateLocalSpanInterceptor struct {
 }
 
 func (h *CreateLocalSpanInterceptor) BeforeInvoke(invocation operator.Invocation) error {
-	operationName := invocation.Args()[0].(string)
-	s, err := tracing.CreateLocalSpan(operationName)
-	invocation.DefineReturnValues(s, err)
 	return nil
 }
 
 func (h *CreateLocalSpanInterceptor) AfterInvoke(invocation operator.Invocation, result ...interface{}) error {
+	operationName := invocation.Args()[0].(string)
+	s, _ := tracing.CreateLocalSpan(operationName)
+	enhancced, ok := result[0].(operator.EnhancedInstance)
+	if !ok {
+		return nil
+	}
+	enhancced.SetSkyWalkingDynamicField(s)
 	return nil
 }

--- a/plugins/trace-activation/instrument.go
+++ b/plugins/trace-activation/instrument.go
@@ -139,8 +139,13 @@ func (i *Instrument) Points() []*instrument.Point {
 		},
 		{
 			PackagePath: "", PackageName: "trace",
-			At:          instrument.NewMethodEnhance("*SpanRef", "Tag"),
+			At:          instrument.NewMethodEnhance("*SpanRef", "SetTag"),
 			Interceptor: "AsyncTagInterceptor",
+		},
+		{
+			PackagePath: "", PackageName: "trace",
+			At:          instrument.NewMethodEnhance("*SpanRef", "AddLog"),
+			Interceptor: "AsyncLogInterceptor",
 		},
 	}
 }

--- a/plugins/trace-activation/instrument.go
+++ b/plugins/trace-activation/instrument.go
@@ -50,6 +50,10 @@ func (i *Instrument) Points() []*instrument.Point {
 	return []*instrument.Point{
 		{
 			PackagePath: "", PackageName: "trace",
+			At: instrument.NewStructEnhance("SpanRef"),
+		},
+		{
+			PackagePath: "", PackageName: "trace",
 			At:          instrument.NewStaticMethodEnhance("CreateEntrySpan"),
 			Interceptor: "CreateEntrySpanInterceptor",
 		},
@@ -110,12 +114,12 @@ func (i *Instrument) Points() []*instrument.Point {
 		},
 		{
 			PackagePath: "", PackageName: "trace",
-			At:          instrument.NewStaticMethodEnhance("PrepareAsync"),
+			At:          instrument.NewMethodEnhance("*SpanRef", "PrepareAsync"),
 			Interceptor: "PrepareAsyncInterceptor",
 		},
 		{
 			PackagePath: "", PackageName: "trace",
-			At:          instrument.NewStaticMethodEnhance("AsyncFinish"),
+			At:          instrument.NewMethodEnhance("*SpanRef", "AsyncFinish"),
 			Interceptor: "AsyncFinishInterceptor",
 		},
 		{
@@ -132,6 +136,11 @@ func (i *Instrument) Points() []*instrument.Point {
 			PackagePath: "", PackageName: "trace",
 			At:          instrument.NewStaticMethodEnhance("SetComponent"),
 			Interceptor: "SetComponentInterceptor",
+		},
+		{
+			PackagePath: "", PackageName: "trace",
+			At:          instrument.NewMethodEnhance("*SpanRef", "Tag"),
+			Interceptor: "AsyncTagInterceptor",
 		},
 	}
 }

--- a/plugins/trace-activation/instrument.go
+++ b/plugins/trace-activation/instrument.go
@@ -88,6 +88,14 @@ func (i *Instrument) Points() []*instrument.Point {
 			Interceptor: "GetSpanIDInterceptor",
 		},
 		{
+			PackagePath: "", PackageName: "trace", At: instrument.NewMethodEnhance("*SpanRef", "SetTag"),
+			Interceptor: "AsyncTagInterceptor",
+		},
+		{
+			PackagePath: "", PackageName: "trace", At: instrument.NewMethodEnhance("*SpanRef", "AddLog"),
+			Interceptor: "AsyncLogInterceptor",
+		},
+		{
 			PackagePath: "", PackageName: "trace", At: instrument.NewStaticMethodEnhance("AddLog"),
 			Interceptor: "AddLogInterceptor",
 		},
@@ -118,14 +126,6 @@ func (i *Instrument) Points() []*instrument.Point {
 		{
 			PackagePath: "", PackageName: "trace", At: instrument.NewStaticMethodEnhance("SetComponent"),
 			Interceptor: "SetComponentInterceptor",
-		},
-		{
-			PackagePath: "", PackageName: "trace", At: instrument.NewMethodEnhance("*SpanRef", "SetTag"),
-			Interceptor: "AsyncTagInterceptor",
-		},
-		{
-			PackagePath: "", PackageName: "trace", At: instrument.NewMethodEnhance("*SpanRef", "AddLog"),
-			Interceptor: "AsyncLogInterceptor",
 		},
 	}
 }

--- a/plugins/trace-activation/instrument.go
+++ b/plugins/trace-activation/instrument.go
@@ -49,102 +49,82 @@ func (i *Instrument) VersionChecker(version string) bool {
 func (i *Instrument) Points() []*instrument.Point {
 	return []*instrument.Point{
 		{
-			PackagePath: "", PackageName: "trace",
-			At: instrument.NewStructEnhance("SpanRef"),
+			PackagePath: "", PackageName: "trace", At: instrument.NewStructEnhance("SpanRef"),
 		},
 		{
-			PackagePath: "", PackageName: "trace",
-			At:          instrument.NewStaticMethodEnhance("CreateEntrySpan"),
+			PackagePath: "", PackageName: "trace", At: instrument.NewStaticMethodEnhance("CreateEntrySpan"),
 			Interceptor: "CreateEntrySpanInterceptor",
 		},
 		{
-			PackagePath: "", PackageName: "trace",
-			At:          instrument.NewStaticMethodEnhance("CreateLocalSpan"),
+			PackagePath: "", PackageName: "trace", At: instrument.NewStaticMethodEnhance("CreateLocalSpan"),
 			Interceptor: "CreateLocalSpanInterceptor",
 		},
 		{
-			PackagePath: "", PackageName: "trace",
-			At:          instrument.NewStaticMethodEnhance("CreateExitSpan"),
+			PackagePath: "", PackageName: "trace", At: instrument.NewStaticMethodEnhance("CreateExitSpan"),
 			Interceptor: "CreateExitSpanInterceptor",
 		},
 		{
-			PackagePath: "", PackageName: "trace",
-			At:          instrument.NewStaticMethodEnhance("StopSpan"),
+			PackagePath: "", PackageName: "trace", At: instrument.NewStaticMethodEnhance("StopSpan"),
 			Interceptor: "StopSpanInterceptor",
 		},
 		{
-			PackagePath: "", PackageName: "trace",
-			At:          instrument.NewStaticMethodEnhance("CaptureContext"),
+			PackagePath: "", PackageName: "trace", At: instrument.NewStaticMethodEnhance("CaptureContext"),
 			Interceptor: "CaptureContextInterceptor",
 		},
 		{
-			PackagePath: "", PackageName: "trace",
-			At:          instrument.NewStaticMethodEnhance("ContinueContext"),
+			PackagePath: "", PackageName: "trace", At: instrument.NewStaticMethodEnhance("ContinueContext"),
 			Interceptor: "ContinueContextInterceptor",
 		},
 		{
-			PackagePath: "", PackageName: "trace",
-			At:          instrument.NewStaticMethodEnhance("GetTraceID"),
+			PackagePath: "", PackageName: "trace", At: instrument.NewStaticMethodEnhance("GetTraceID"),
 			Interceptor: "GetTraceIDInterceptor",
 		},
 		{
-			PackagePath: "", PackageName: "trace",
-			At:          instrument.NewStaticMethodEnhance("GetSegmentID"),
+			PackagePath: "", PackageName: "trace", At: instrument.NewStaticMethodEnhance("GetSegmentID"),
 			Interceptor: "GetSegmentIDInterceptor",
 		},
 		{
-			PackagePath: "", PackageName: "trace",
-			At:          instrument.NewStaticMethodEnhance("GetSpanID"),
+			PackagePath: "", PackageName: "trace", At: instrument.NewStaticMethodEnhance("GetSpanID"),
 			Interceptor: "GetSpanIDInterceptor",
 		},
 		{
-			PackagePath: "", PackageName: "trace",
-			At:          instrument.NewStaticMethodEnhance("AddLog"),
+			PackagePath: "", PackageName: "trace", At: instrument.NewStaticMethodEnhance("AddLog"),
 			Interceptor: "AddLogInterceptor",
 		},
 		{
-			PackagePath: "", PackageName: "trace",
-			At:          instrument.NewStaticMethodEnhance("SetTag"),
+			PackagePath: "", PackageName: "trace", At: instrument.NewStaticMethodEnhance("SetTag"),
 			Interceptor: "SetTagInterceptor",
 		},
 		{
-			PackagePath: "", PackageName: "trace",
-			At:          instrument.NewStaticMethodEnhance("SetOperationName"),
+			PackagePath: "", PackageName: "trace", At: instrument.NewStaticMethodEnhance("SetOperationName"),
 			Interceptor: "SetOperationNameInterceptor",
 		},
 		{
-			PackagePath: "", PackageName: "trace",
-			At:          instrument.NewMethodEnhance("*SpanRef", "PrepareAsync"),
+			PackagePath: "", PackageName: "trace", At: instrument.NewMethodEnhance("*SpanRef", "PrepareAsync"),
 			Interceptor: "PrepareAsyncInterceptor",
 		},
 		{
-			PackagePath: "", PackageName: "trace",
-			At:          instrument.NewMethodEnhance("*SpanRef", "AsyncFinish"),
+			PackagePath: "", PackageName: "trace", At: instrument.NewMethodEnhance("*SpanRef", "AsyncFinish"),
 			Interceptor: "AsyncFinishInterceptor",
 		},
 		{
-			PackagePath: "", PackageName: "trace",
-			At:          instrument.NewStaticMethodEnhance("GetCorrelation"),
+			PackagePath: "", PackageName: "trace", At: instrument.NewStaticMethodEnhance("GetCorrelation"),
 			Interceptor: "GetCorrelationInterceptor",
 		},
 		{
-			PackagePath: "", PackageName: "trace",
-			At:          instrument.NewStaticMethodEnhance("SetCorrelation"),
+			PackagePath: "", PackageName: "trace", At: instrument.NewStaticMethodEnhance("SetCorrelation"),
 			Interceptor: "SetCorrelationInterceptor",
 		},
 		{
-			PackagePath: "", PackageName: "trace",
-			At:          instrument.NewStaticMethodEnhance("SetComponent"),
+			PackagePath: "", PackageName: "trace", At: instrument.NewStaticMethodEnhance("SetComponent"),
 			Interceptor: "SetComponentInterceptor",
 		},
 		{
-			PackagePath: "", PackageName: "trace",
-			At:          instrument.NewMethodEnhance("*SpanRef", "SetTag"),
+			PackagePath: "", PackageName: "trace", At: instrument.NewMethodEnhance("*SpanRef", "SetTag"),
 			Interceptor: "AsyncTagInterceptor",
 		},
 		{
-			PackagePath: "", PackageName: "trace",
-			At:          instrument.NewMethodEnhance("*SpanRef", "AddLog"),
+			PackagePath: "", PackageName: "trace", At: instrument.NewMethodEnhance("*SpanRef", "AddLog"),
 			Interceptor: "AsyncLogInterceptor",
 		},
 	}

--- a/test/plugins/scenarios/trace-activation/config/excepted.yml
+++ b/test/plugins/scenarios/trace-activation/config/excepted.yml
@@ -214,7 +214,10 @@ segmentItems:
             peer: ''
             skipAnalysis: false
             tags:
-              - { key: testAsyncInCrossGoroutine, value: success }
+              - { key: testAsyncTag, value: success }
+            logs:
+              - logEvent:
+                  - { key: testAsyncLog, value: success }
           - operationName: GET:/consumer
             parentSpanId: -1
             spanId: 0

--- a/test/plugins/scenarios/trace-activation/config/excepted.yml
+++ b/test/plugins/scenarios/trace-activation/config/excepted.yml
@@ -202,6 +202,19 @@ segmentItems:
             spanType: Local
             peer: ''
             skipAnalysis: false
+          - operationName: testAsyncInCrossGoroutine
+            parentSpanId: 8
+            spanId: 13
+            spanLayer: Unknown
+            startTime: nq 0
+            endTime: nq 0
+            componentId: 0
+            isError: false
+            spanType: Local
+            peer: ''
+            skipAnalysis: false
+            tags:
+              - { key: testAsyncInCrossGoroutine, value: success }
           - operationName: GET:/consumer
             parentSpanId: -1
             spanId: 0

--- a/test/plugins/scenarios/trace-activation/main.go
+++ b/test/plugins/scenarios/trace-activation/main.go
@@ -41,6 +41,7 @@ func consumerHandler(w http.ResponseWriter, r *http.Request) {
 	testContext()
 	testContextCarrier()
 	testComponent()
+	testAsyncInCrossGoroutine()
 }
 
 func main() {

--- a/test/plugins/scenarios/trace-activation/test_service.go
+++ b/test/plugins/scenarios/trace-activation/test_service.go
@@ -110,7 +110,8 @@ func testAsyncInCrossGoroutine() {
 	s.PrepareAsync()
 	trace.StopSpan()
 	go func() {
-		s.Tag("testAsyncInCrossGoroutine", "success")
+		s.SetTag("testAsyncTag", "success")
+		s.AddLog("testAsyncLog", "success")
 		s.AsyncFinish()
 		ch <- ""
 	}()

--- a/test/plugins/scenarios/trace-activation/test_service.go
+++ b/test/plugins/scenarios/trace-activation/test_service.go
@@ -103,3 +103,16 @@ func testComponent() {
 	trace.SetComponent(5006)
 	trace.StopSpan()
 }
+
+func testAsyncInCrossGoroutine() {
+	var ch = make(chan string)
+	s, _ := trace.CreateLocalSpan("testAsyncInCrossGoroutine")
+	s.PrepareAsync()
+	trace.StopSpan()
+	go func() {
+		s.Tag("testAsyncInCrossGoroutine", "success")
+		s.AsyncFinish()
+		ch <- ""
+	}()
+	<-ch
+}

--- a/toolkit/trace/api.go
+++ b/toolkit/trace/api.go
@@ -17,6 +17,16 @@
 
 package trace
 
+type ExtractorRef func(headerKey string) (string, error)
+
+type InjectorRef func(headerKey, headerValue string) error
+
+type ContextSnapshotRef interface {
+}
+
+type SpanRef struct {
+}
+
 func CreateEntrySpan(operationName string, extractor ExtractorRef) (s *SpanRef, err error) {
 	return &SpanRef{}, err
 }
@@ -71,14 +81,4 @@ func SetCorrelation(key string, value string) {
 }
 
 func SetComponent(componentID int32) {
-}
-
-func (*SpanRef) PrepareAsync() {
-}
-
-func (*SpanRef) AsyncFinish() {
-}
-
-// nolint
-func (*SpanRef) Tag(key string, value string) {
 }

--- a/toolkit/trace/api.go
+++ b/toolkit/trace/api.go
@@ -17,17 +17,17 @@
 
 package trace
 
-func CreateEntrySpan(operationName string, extractor ExtractorRef) (s SpanRef, err error) {
-	return nil, err
+func CreateEntrySpan(operationName string, extractor ExtractorRef) (s *SpanRef, err error) {
+	return &SpanRef{}, err
 }
 
 // nolint
-func CreateExitSpan(operationName string, peer string, injector InjectorRef) (s SpanRef, err error) {
-	return nil, err
+func CreateExitSpan(operationName string, peer string, injector InjectorRef) (s *SpanRef, err error) {
+	return &SpanRef{}, err
 }
 
-func CreateLocalSpan(operationName string) (s SpanRef, err error) {
-	return nil, err
+func CreateLocalSpan(operationName string) (s *SpanRef, err error) {
+	return &SpanRef{}, err
 }
 
 func StopSpan() {
@@ -62,12 +62,6 @@ func SetTag(key string, value string) {
 func AddLog(...string) {
 }
 
-func PrepareAsync() {
-}
-
-func AsyncFinish() {
-}
-
 func GetCorrelation(key string) string {
 	return ""
 }
@@ -77,4 +71,14 @@ func SetCorrelation(key string, value string) {
 }
 
 func SetComponent(componentID int32) {
+}
+
+func (*SpanRef) PrepareAsync() {
+}
+
+func (*SpanRef) AsyncFinish() {
+}
+
+// nolint
+func (*SpanRef) Tag(key string, value string) {
 }

--- a/toolkit/trace/span.go
+++ b/toolkit/trace/span.go
@@ -21,5 +21,5 @@ type ExtractorRef func(headerKey string) (string, error)
 
 type InjectorRef func(headerKey, headerValue string) error
 
-type SpanRef interface {
+type SpanRef struct {
 }

--- a/toolkit/trace/span.go
+++ b/toolkit/trace/span.go
@@ -17,9 +17,15 @@
 
 package trace
 
-type ExtractorRef func(headerKey string) (string, error)
+func (*SpanRef) PrepareAsync() {
+}
 
-type InjectorRef func(headerKey, headerValue string) error
+func (*SpanRef) AsyncFinish() {
+}
 
-type SpanRef struct {
+// nolint
+func (*SpanRef) SetTag(key string, value string) {
+}
+
+func (*SpanRef) AddLog(...string) {
 }


### PR DESCRIPTION
## Description

In the process of writing my blog, I found that Async API in manual APIs are not available to users because users cannot pass Span into other goroutines. I accidentally overlooked this before.

Then I referred to JAVA and found that it provides users with a `spanRef` to use async api. (I've defined this `spanRef`, but it's currently no use)
![Screenshot_20231025_122044](https://github.com/apache/skywalking-go/assets/93872575/cb40b87f-6368-492e-a5fa-30e4d68c7476)

So I changed the async api.

## Change
- fix Async API in manual APIs
- Supplement cross goroutine async test