### PR TITLE
fix: limit the bytes of redis args

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@ Release Notes.
 
 #### Plugins
 * Support setting a discard type of reporter.
+* Add `redis.max_args_bytes` parameter for redis plugin.
 
 #### Documentation
 
@@ -65,7 +66,7 @@ Release Notes.
 
 #### Documentation
 * Combine `Supported Libraries` and `Performance Test` into `Plugins` section.
-* Add `Tracing, Metrics and Logging` document into `Plugins` section. 
+* Add `Tracing, Metrics and Logging` document into `Plugins` section.
 
 #### Bug Fixes
 * Fix throw panic when log the tracing context before agent core initialized.

--- a/docs/en/agent/plugin-configurations.md
+++ b/docs/en/agent/plugin-configurations.md
@@ -4,6 +4,6 @@
 |--------------------------------|-------------------------------------------------------|---------------|----------------------------------------------------------------|
 | http.server_collect_parameters | SW_AGENT_PLUGIN_CONFIG_HTTP_SERVER_COLLECT_PARAMETERS | false         | Collect the parameters of the HTTP request on the server side. |
 | mongo.collect_statement        | SW_AGENT_PLUGIN_CONFIG_MONGO_COLLECT_STATEMENT        | false         | Collect the statement of the MongoDB request.                  |
-| redis.max_args_bytes | SW_AGENT_PLUGIN_CONFIG_REDIS_MAX_ARGS_BYTES | 1024 | Limit the bytes size of redis args request.                  |
 | sql.collect_parameter          | SW_AGENT_PLUGIN_CONFIG_SQL_COLLECT_PARAMETER          | false         | Collect the parameter of the SQL request.                      |
+| redis.max_args_bytes           | SW_AGENT_PLUGIN_CONFIG_REDIS_MAX_ARGS_BYTES           | 1024          | Limit the bytes size of redis args request.                    |
 | reporter.discard               | SW_AGENT_REPORTER_DISCARD                             | false         | Discard the reporter.                                          |

--- a/docs/en/agent/plugin-configurations.md
+++ b/docs/en/agent/plugin-configurations.md
@@ -4,5 +4,6 @@
 |--------------------------------|-------------------------------------------------------|---------------|----------------------------------------------------------------|
 | http.server_collect_parameters | SW_AGENT_PLUGIN_CONFIG_HTTP_SERVER_COLLECT_PARAMETERS | false         | Collect the parameters of the HTTP request on the server side. |
 | mongo.collect_statement        | SW_AGENT_PLUGIN_CONFIG_MONGO_COLLECT_STATEMENT        | false         | Collect the statement of the MongoDB request.                  |
+| redis.max_args_bytes | SW_AGENT_PLUGIN_CONFIG_REDIS_MAX_ARGS_BYTES | 1024 | Limit the bytes size of redis args request.                  |
 | sql.collect_parameter          | SW_AGENT_PLUGIN_CONFIG_SQL_COLLECT_PARAMETER          | false         | Collect the parameter of the SQL request.                      |
 | reporter.discard               | SW_AGENT_REPORTER_DISCARD                             | false         | Discard the reporter.                                          |

--- a/plugins/go-redisv9/config.go
+++ b/plugins/go-redisv9/config.go
@@ -1,0 +1,23 @@
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Apache Software Foundation (ASF) licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package goredisv9
+
+//skywalking:config redis
+var config struct {
+	MaxArgsBytes int `config:"max_args_bytes"`
+}

--- a/plugins/go-redisv9/hook.go
+++ b/plugins/go-redisv9/hook.go
@@ -99,7 +99,7 @@ func (r *redisHook) ProcessHook(next redis.ProcessHook) redis.ProcessHook {
 			tracing.WithTag(tracing.TagCacheOp, getCacheOp(cmd.FullName())),
 			tracing.WithTag(tracing.TagCacheCmd, cmd.FullName()),
 			tracing.WithTag(tracing.TagCacheKey, getKey(cmd.Args())),
-			tracing.WithTag(tracing.TagCacheArgs, cmd.String()),
+			tracing.WithTag(tracing.TagCacheArgs, maxString(cmd.String(), config.MaxArgsBytes)),
 		)
 
 		if err != nil {
@@ -186,4 +186,16 @@ func getKey(args []interface{}) string {
 		}
 	}
 	return key
+}
+
+// maxString limit the bytes length of the redis args.
+func maxString(s string, length int) string {
+	if length <= 0 { // no define or no limit
+		return s
+	}
+
+	if len(s) > length {
+		return s[:length]
+	}
+	return s
 }

--- a/test/plugins/scenarios/go-redisv9/bin/startup.sh
+++ b/test/plugins/scenarios/go-redisv9/bin/startup.sh
@@ -19,4 +19,6 @@
 home="$(cd "$(dirname $0)"; pwd)"
 go build ${GO_BUILD_OPTS} -o goredisv9
 
+export SW_AGENT_PLUGIN_CONFIG_REDIS_MAX_ARGS_BYTES=1024
+
 ./goredisv9

--- a/tools/go-agent/config/agent.default.yaml
+++ b/tools/go-agent/config/agent.default.yaml
@@ -92,3 +92,6 @@ plugin:
     sql:
       # Collect the parameter of the SQL request
       collect_parameter: ${SW_AGENT_PLUGIN_CONFIG_SQL_COLLECT_PARAMETER:false}
+    redis:
+      # Limit the bytes size of redis args request
+      max_args_bytes: ${SW_AGENT_PLUGIN_CONFIG_REDIS_MAX_ARGS_BYTES:1024}

--- a/tools/go-agent/instrument/plugins/enhance_config.go
+++ b/tools/go-agent/instrument/plugins/enhance_config.go
@@ -215,7 +215,7 @@ func (f *ConfigField) GenerateAssignFieldValue(varName string, field, path []str
 		getFromEnvStr = fmt.Sprintf("if v := tools.GetEnvValue(%q); v != \"\" { result = v };", pluginConfig.EnvKey)
 	}
 	parseResStr := ""
-	parseErrorMessage := "cannot parse the config " + fieldKeyPathStr + ": err.Error()"
+	parseErrorMessage := fmt.Sprintf(`"cannot parse the config %s: " + err.Error()`, fieldKeyPathStr)
 	switch f.Type {
 	case "string":
 		parseResStr = "return result"


### PR DESCRIPTION
### summary

limit the bytes of redis args.