### PR TITLE
feat: add client ip in gin

### DIFF
--- a/plugins/core/tracing/span.go
+++ b/plugins/core/tracing/span.go
@@ -50,6 +50,8 @@ type Tag string
 
 const (
 	TagURL             = "url"
+	TagRemoteAddr      = "remote_addr"
+	TagClientIP        = "client_ip"
 	TagStatusCode      = "status_code"
 	TagHTTPMethod      = "http.method"
 	TagHTTPParams      = "http.params"

--- a/plugins/core/tracing/span.go
+++ b/plugins/core/tracing/span.go
@@ -50,7 +50,7 @@ type Tag string
 
 const (
 	TagURL             = "url"
-	TagRemoteAddr      = "remote_addr"
+	TagRemoteIP        = "remote_ip"
 	TagClientIP        = "client_ip"
 	TagStatusCode      = "status_code"
 	TagHTTPMethod      = "http.method"

--- a/plugins/gin/intercepter.go
+++ b/plugins/gin/intercepter.go
@@ -53,6 +53,8 @@ func (h *HTTPInterceptor) AfterInvoke(invocation operator.Invocation, result ...
 	context := invocation.Args()[0].(*gin.Context)
 	span := invocation.GetContext().(tracing.Span)
 	span.Tag(tracing.TagStatusCode, fmt.Sprintf("%d", context.Writer.Status()))
+	span.Tag(tracing.TagRemoteAddr, context.RemoteIP())
+	span.Tag(tracing.TagClientIP, context.ClientIP())
 	if len(context.Errors) > 0 {
 		span.Error(context.Errors.String())
 	}

--- a/plugins/gin/intercepter.go
+++ b/plugins/gin/intercepter.go
@@ -53,7 +53,7 @@ func (h *HTTPInterceptor) AfterInvoke(invocation operator.Invocation, result ...
 	context := invocation.Args()[0].(*gin.Context)
 	span := invocation.GetContext().(tracing.Span)
 	span.Tag(tracing.TagStatusCode, fmt.Sprintf("%d", context.Writer.Status()))
-	span.Tag(tracing.TagRemoteAddr, context.RemoteIP())
+	span.Tag(tracing.TagRemoteIP, context.RemoteIP())
 	span.Tag(tracing.TagClientIP, context.ClientIP())
 	if len(context.Errors) > 0 {
 		span.Error(context.Errors.String())

--- a/plugins/gin/intercepter_test.go
+++ b/plugins/gin/intercepter_test.go
@@ -69,7 +69,7 @@ func TestInvoke(t *testing.T) {
 	}
 
 	assert.Equal(t, tags["client_ip"], "127.0.0.1")
-	assert.Equal(t, tags["remote_addr"], "127.0.0.1")
+	assert.Equal(t, tags["remote_ip"], "127.0.0.1")
 }
 
 type testWriter struct {


### PR DESCRIPTION
### summary

1. add remoteip and clientip to span.tags in gin.
2. ut.