### PR TITLE
bugfix:forget to set metrics & log ch as well

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,7 +15,7 @@ Release Notes.
 #### Bug Fixes
 * Fix users can not use async api in toolkit-trace.
 * Fix cannot enhance the vendor management project.
-
+* Fix SW_AGENT_REPORTER_GRPC_MAX_SEND_QUEUE not working on metricsSendCh & logSendCh chans of gRPC reporter.
 #### Issues and PR
 - All issues are [here](https://github.com/apache/skywalking/milestone/197?closed=1)
 - All and pull requests are [here](https://github.com/apache/skywalking-go/milestone/4?closed=1)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,7 @@ Release Notes.
 * Fix users can not use async api in toolkit-trace.
 * Fix cannot enhance the vendor management project.
 * Fix SW_AGENT_REPORTER_GRPC_MAX_SEND_QUEUE not working on metricsSendCh & logSendCh chans of gRPC reporter.
+
 #### Issues and PR
 - All issues are [here](https://github.com/apache/skywalking/milestone/197?closed=1)
 - All and pull requests are [here](https://github.com/apache/skywalking-go/milestone/4?closed=1)

--- a/plugins/core/reporter/grpc/grpc_opts_enhance.go
+++ b/plugins/core/reporter/grpc/grpc_opts_enhance.go
@@ -28,6 +28,7 @@ import (
 	"google.golang.org/grpc/metadata"
 
 	agentv3 "skywalking.apache.org/repo/goapi/collect/language/agent/v3"
+	logv3 "skywalking.apache.org/repo/goapi/collect/logging/v3"
 )
 
 var authKey = "Authentication"
@@ -47,6 +48,8 @@ func WithCheckInterval(interval time.Duration) ReporterOption {
 func WithMaxSendQueueSize(maxSendQueueSize int) ReporterOption {
 	return func(r *gRPCReporter) {
 		r.tracingSendCh = make(chan *agentv3.SegmentObject, maxSendQueueSize)
+		r.metricsSendCh = make(chan []*agentv3.MeterData, maxSendQueueSize)
+		r.logSendCh = make(chan *logv3.LogData, maxSendQueueSize)
 	}
 }
 


### PR DESCRIPTION
 for the setting SW_AGENT_REPORTER_GRPC_MAX_SEND_QUEUE in the https://github.com/apache/skywalking-go/blob/99c2c38ff78507db17aa14839047219a2a6c99b8/tools/go-agent/config/agent.default.yaml

found out that its not working on metricsSendCh & logSendCh chans