### PR TITLE
Add support ignore suffix

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@ Release Notes.
 0.4.0
 ------------------
 #### Features
+* Add support ignore suffix.
 
 #### Plugins
 * Support setting a discard type of reporter.

--- a/docs/en/agent/tracing-metrics-logging.md
+++ b/docs/en/agent/tracing-metrics-logging.md
@@ -22,9 +22,10 @@ If you wish to disable a particular plugin to prevent enhancements related to th
 
 The basic configuration is as follows:
 
-| Name                    | Environment Key   | Default Value         | Description                                                                                                                               |
-|-------------------------|-------------------|-----------------------|-------------------------------------------------------------------------------------------------------------------------------------------|
-| agent.sampler           | SW_AGENT_SAMPLER  | 1                     | Sampling rate of tracing data, which is a floating-point value that must be between 0 and 1.                                              |
+| Name                | Environment Key        | Default Value                                                | Description                                                                                                              |
+|---------------------|------------------------|--------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------|
+| agent.sampler       | SW_AGENT_SAMPLER       | 1                                                            | Sampling rate of tracing data, which is a floating-point value that must be between 0 and 1.                             |
+| agent.ignore_suffix | SW_AGENT_IGNORE_SUFFIX | .jpg,.jpeg,.js,.css,.png,.bmp,.gif,.ico,.mp3,.mp4,.html,.svg | If the operation name of the first span is included in this set, this segment should be ignored.(multiple split by ","). |
 
 ## Metrics
 

--- a/plugins/core/tracer.go
+++ b/plugins/core/tracer.go
@@ -22,6 +22,7 @@ import (
 	defLog "log"
 	"os"
 	"reflect"
+	"strings"
 	"sync"
 
 	"github.com/apache/skywalking-go/plugins/core/operator"
@@ -52,10 +53,11 @@ type Tracer struct {
 	// for all metrics
 	meterMap              *sync.Map
 	meterCollectListeners []func()
+	ignoreSuffix          []string
 }
 
 func (t *Tracer) Init(entity *reporter.Entity, rep reporter.Reporter, samp Sampler, logger operator.LogOperator,
-	meterCollectSecond int, correlation *CorrelationConfig) error {
+	meterCollectSecond int, correlation *CorrelationConfig, ignoreSuffixStr string) error {
 	t.ServiceEntity = entity
 	t.Reporter = rep
 	t.Sampler = samp
@@ -66,6 +68,7 @@ func (t *Tracer) Init(entity *reporter.Entity, rep reporter.Reporter, samp Sampl
 	t.initFlag = 1
 	t.initMetricsCollect(meterCollectSecond)
 	t.correlation = correlation
+	t.ignoreSuffix = strings.Split(ignoreSuffixStr, ",")
 	// notify the tracer been init success
 	if len(GetInitNotify()) > 0 {
 		for _, fun := range GetInitNotify() {

--- a/tools/go-agent/config/agent.default.yaml
+++ b/tools/go-agent/config/agent.default.yaml
@@ -30,6 +30,8 @@ agent:
   correlation:
     max_key_count: ${SW_AGENT_CORRELATION_MAX_KEY_COUNT:3}
     max_value_size: ${SW_AGENT_CORRELATION_MAX_VALUE_SIZE:128}
+  # If the operation name of the first span is included in this set, this segment should be ignored.(multiple split by ",")
+  ignore_suffix: ${SW_AGENT_IGNORE_SUFFIX:.jpg,.jpeg,.js,.css,.png,.bmp,.gif,.ico,.mp3,.mp4,.html,.svg}
 
 reporter:
   discard: ${SW_AGENT_REPORTER_DISCARD:false}

--- a/tools/go-agent/config/loader.go
+++ b/tools/go-agent/config/loader.go
@@ -50,6 +50,7 @@ type Agent struct {
 	Sampler         StringValue `yaml:"sampler"`
 	Meter           Meter       `yaml:"meter"`
 	Correlation     Correlation `yaml:"correlation"`
+	IgnoreSuffix    StringValue `yaml:"ignore_suffix"`
 }
 
 type Reporter struct {

--- a/tools/go-agent/instrument/agentcore/instrument.go
+++ b/tools/go-agent/instrument/agentcore/instrument.go
@@ -162,7 +162,8 @@ func (t *Tracer) InitTracer(extend map[string]interface{}) {
 		MaxKeyCount : {{.Config.Agent.Correlation.MaxKeyCount.ToGoIntValue "loading the agent correlation maxKeyCount error"}},
 		MaxValueSize : {{.Config.Agent.Correlation.MaxValueSize.ToGoIntValue "loading the agent correlation maxValueSize error"}},
 	}
-	if err := t.Init(entity, rep, samp, logger, meterCollectInterval, correlation); err != nil {
+	ignoreSuffixStr := {{.Config.Agent.IgnoreSuffix.ToGoStringValue}}
+	if err := t.Init(entity, rep, samp, logger, meterCollectInterval, correlation, ignoreSuffixStr); err != nil {
 		t.Log.Errorf("cannot initialize the SkyWalking Tracer: %v", err)
 	}
 }`, struct {


### PR DESCRIPTION
### summary
add support ignore suffix

### what
Provide users with the ability to ignore the span for the operationName dimension.

### why
In the actual usage environment, there are a batch of requests such as /xx.jpg. We can reduce the signal-to-noise ratio of the collection to better analyze the trace.

### how
I added `agent.ignore_suffix` in the default configuration file, which will add a layer of judgment when creating Entry, Local and Exit spans.

### additional
There is no test code added for the time being. Since I am considering the operationName dimension, I would like to discuss the topic [11807](https://github.com/apache/skywalking/discussions/11807) with community members~