### PR TITLE
fix lost trace when multi middleware handlerFunc

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,6 +22,7 @@ Release Notes.
 * Fix enhance method error when unknown parameter type.
 * Fix wrong tracing context when trace have been sampled.
 * Fix enhance param error when there are multiple params.
+* Fix lost trace when multi middleware handlerFunc.
 
 #### Issues and PR
 - All issues are [here](https://github.com/apache/skywalking/milestone/197?closed=1)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,7 +22,7 @@ Release Notes.
 * Fix enhance method error when unknown parameter type.
 * Fix wrong tracing context when trace have been sampled.
 * Fix enhance param error when there are multiple params.
-* Fix lost trace when multi middleware handlerFunc.
+* Fix lost trace when multi middleware `handlerFunc` in `gin` plugin.
 
 #### Issues and PR
 - All issues are [here](https://github.com/apache/skywalking/milestone/197?closed=1)

--- a/plugins/gin/structures.go
+++ b/plugins/gin/structures.go
@@ -1,0 +1,23 @@
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Apache Software Foundation (ASF) licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package gin
+
+//skywalking:native github.com/gin-gonic/gin Context
+type nativeContext struct {
+	index int8
+}


### PR DESCRIPTION
using the index of `[]HandlerFunc`, determine if the current is the first HandlerFunc, and then handle the enhancement
 
[#11852](https://github.com/apache/skywalking/issues/11852)