### PR TITLE
Add support trace ignore

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,9 @@ Release Notes.
 
 0.5.0
 ------------------
+#### Features
+* Add support trace ignore.
+
 #### Plugins
 * Support [Pulsar](https://github.com/apache/pulsar-client-go) MQ.
 * Support [Segmentio-Kafka](https://github.com/segmentio/kafka-go) MQ.
@@ -111,7 +114,7 @@ Release Notes.
 * Support [Kratos](github.com/go-kratos/kratos) v2 server and client framework.
 * Support [Go-Micro](https://github.com/go-micro/go-micro) v4 server and client framework.
 * Support [GORM](https://github.com/go-gorm/gorm) v2 database client framework.
-  * Support [MySQL Driver](https://github.com/go-gorm/mysql) detection.
+* Support [MySQL Driver](https://github.com/go-gorm/mysql) detection.
 
 #### Documentation
 * Initialize the documentation.

--- a/docs/en/agent/tracing-metrics-logging.md
+++ b/docs/en/agent/tracing-metrics-logging.md
@@ -22,11 +22,11 @@ If you wish to disable a particular plugin to prevent enhancements related to th
 
 The basic configuration is as follows:
 
-| Name                    | Environment Key            | Default Value                                                | Description                                                                                                              |
-|-------------------------|----------------------------|--------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------|
-| agent.sampler           | SW_AGENT_SAMPLER           | 1                                                            | Sampling rate of tracing data, which is a floating-point value that must be between 0 and 1.                             |
-| agent.ignore_suffix     | SW_AGENT_IGNORE_SUFFIX     | .jpg,.jpeg,.js,.css,.png,.bmp,.gif,.ico,.mp3,.mp4,.html,.svg | If the operation name of the first span is included in this set, this segment should be ignored.(multiple split by ","). |
-| agent.trace_ignore_path | SW_AGENT_TRACE_IGNORE_PATH |                                                              | If the operation name of the first span is matching, this segment should be ignored.(multiple split by ",").             |
+| Name                    | Environment Key            | Default Value                                                | Description                                                                                                                                          |
+|-------------------------|----------------------------|--------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------|
+| agent.sampler           | SW_AGENT_SAMPLER           | 1                                                            | Sampling rate of tracing data, which is a floating-point value that must be between 0 and 1.                                                         |
+| agent.ignore_suffix     | SW_AGENT_IGNORE_SUFFIX     | .jpg,.jpeg,.js,.css,.png,.bmp,.gif,.ico,.mp3,.mp4,.html,.svg | If the suffix obtained by splitting the operation name by the last index of "." in this set, this segment should be ignored.(multiple split by ","). |
+| agent.trace_ignore_path | SW_AGENT_TRACE_IGNORE_PATH |                                                              | If the operation name of the first span is matching, this segment should be ignored.(multiple split by ",").                                         |
 
 ## Metrics
 

--- a/docs/en/agent/tracing-metrics-logging.md
+++ b/docs/en/agent/tracing-metrics-logging.md
@@ -22,10 +22,11 @@ If you wish to disable a particular plugin to prevent enhancements related to th
 
 The basic configuration is as follows:
 
-| Name                | Environment Key        | Default Value                                                | Description                                                                                                              |
-|---------------------|------------------------|--------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------|
-| agent.sampler       | SW_AGENT_SAMPLER       | 1                                                            | Sampling rate of tracing data, which is a floating-point value that must be between 0 and 1.                             |
-| agent.ignore_suffix | SW_AGENT_IGNORE_SUFFIX | .jpg,.jpeg,.js,.css,.png,.bmp,.gif,.ico,.mp3,.mp4,.html,.svg | If the operation name of the first span is included in this set, this segment should be ignored.(multiple split by ","). |
+| Name                    | Environment Key            | Default Value                                                | Description                                                                                                              |
+|-------------------------|----------------------------|--------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------|
+| agent.sampler           | SW_AGENT_SAMPLER           | 1                                                            | Sampling rate of tracing data, which is a floating-point value that must be between 0 and 1.                             |
+| agent.ignore_suffix     | SW_AGENT_IGNORE_SUFFIX     | .jpg,.jpeg,.js,.css,.png,.bmp,.gif,.ico,.mp3,.mp4,.html,.svg | If the operation name of the first span is included in this set, this segment should be ignored.(multiple split by ","). |
+| agent.trace_ignore_path | SW_AGENT_TRACE_IGNORE_PATH |                                                              | If the operation name of the first span is matching, this segment should be ignored.(multiple split by ",").             |
 
 ## Metrics
 

--- a/plugins/core/tracer.go
+++ b/plugins/core/tracer.go
@@ -54,10 +54,11 @@ type Tracer struct {
 	meterMap              *sync.Map
 	meterCollectListeners []func()
 	ignoreSuffix          []string
+	traceIgnorePath       []string
 }
 
 func (t *Tracer) Init(entity *reporter.Entity, rep reporter.Reporter, samp Sampler, logger operator.LogOperator,
-	meterCollectSecond int, correlation *CorrelationConfig, ignoreSuffixStr string) error {
+	meterCollectSecond int, correlation *CorrelationConfig, ignoreSuffixStr string, ignorePath string) error {
 	t.ServiceEntity = entity
 	t.Reporter = rep
 	t.Sampler = samp
@@ -69,6 +70,7 @@ func (t *Tracer) Init(entity *reporter.Entity, rep reporter.Reporter, samp Sampl
 	t.initMetricsCollect(meterCollectSecond)
 	t.correlation = correlation
 	t.ignoreSuffix = strings.Split(ignoreSuffixStr, ",")
+	t.traceIgnorePath = strings.Split(ignorePath, ",")
 	// notify the tracer been init success
 	if len(GetInitNotify()) > 0 {
 		for _, fun := range GetInitNotify() {

--- a/plugins/core/tracer_ignore.go
+++ b/plugins/core/tracer_ignore.go
@@ -21,17 +21,12 @@ import (
 	"strings"
 )
 
-const (
-	PERIOD = "."
-	COLON  = ":"
-)
-
-func tracerIgnore(operationName string, ignoreSuffixList []string, ignorePath []string) bool {
+func tracerIgnore(operationName string, ignoreSuffixList, ignorePath []string) bool {
 	return ignoreSuffix(operationName, ignoreSuffixList) || traceIgnorePath(operationName, ignorePath)
 }
 
 func ignoreSuffix(operationName string, ignoreSuffix []string) bool {
-	suffixIdx := strings.LastIndex(operationName, PERIOD)
+	suffixIdx := strings.LastIndex(operationName, ".")
 	if suffixIdx == -1 {
 		return false
 	}
@@ -44,11 +39,6 @@ func ignoreSuffix(operationName string, ignoreSuffix []string) bool {
 }
 
 func traceIgnorePath(operationName string, ignorePath []string) bool {
-	op := strings.Index(operationName, COLON)
-	if op == -1 {
-		return false
-	}
-	operationName = operationName[op+1:]
 	for _, pattern := range ignorePath {
 		if normalMatch(pattern, 0, operationName, 0) {
 			return true
@@ -67,9 +57,8 @@ func normalMatch(pat string, p int, str string, s int) bool {
 			if safeCharAt(pat, p) == '*' {
 				p++
 				return multiWildcardMatch(pat, p, str, s)
-			} else {
-				return wildcardMatch(pat, p, str, s)
 			}
+			return wildcardMatch(pat, p, str, s)
 		}
 
 		if (pc == '?' && sc != 0 && sc != '/') || pc == sc {

--- a/plugins/core/tracer_ignore.go
+++ b/plugins/core/tracer_ignore.go
@@ -47,18 +47,20 @@ func traceIgnorePath(operationName string, ignorePath []string) bool {
 	return false
 }
 
-func normalMatch(pat string, p int, str string, s int) bool {
-	for p < len(pat) {
-		pc := pat[p]
-		sc := safeCharAt(str, s)
+// normalMatch determines whether the operation name matches the wildcard pattern.
+// The parameters `p` and `s` represent the current index in pattern and operationName respectively.
+func normalMatch(pattern string, p int, operationName string, s int) bool {
+	for p < len(pattern) {
+		pc := pattern[p]
+		sc := safeCharAt(operationName, s)
 
 		if pc == '*' {
 			p++
-			if safeCharAt(pat, p) == '*' {
+			if safeCharAt(pattern, p) == '*' {
 				p++
-				return multiWildcardMatch(pat, p, str, s)
+				return multiWildcardMatch(pattern, p, operationName, s)
 			}
-			return wildcardMatch(pat, p, str, s)
+			return wildcardMatch(pattern, p, operationName, s)
 		}
 
 		if (pc == '?' && sc != 0 && sc != '/') || pc == sc {
@@ -68,35 +70,35 @@ func normalMatch(pat string, p int, str string, s int) bool {
 		}
 		return false
 	}
-	return s == len(str)
+	return s == len(operationName)
 }
 
-func wildcardMatch(pat string, p int, str string, s int) bool {
-	pc := safeCharAt(pat, p)
+func wildcardMatch(pattern string, p int, operationName string, s int) bool {
+	pc := safeCharAt(pattern, p)
 
 	if pc == 0 {
 		for {
-			sc := safeCharAt(str, s)
+			sc := safeCharAt(operationName, s)
 			if sc == 0 {
 				return true
 			}
 			if sc == '/' {
-				return s == len(str)-1
+				return s == len(operationName)-1
 			}
 			s++
 		}
 	}
 
 	for {
-		sc := safeCharAt(str, s)
+		sc := safeCharAt(operationName, s)
 		if sc == '/' {
 			if pc == sc {
-				return normalMatch(pat, p+1, str, s+1)
+				return normalMatch(pattern, p+1, operationName, s+1)
 			}
 			return false
 		}
-		if !normalMatch(pat, p, str, s) {
-			if s >= len(str) {
+		if !normalMatch(pattern, p, operationName, s) {
+			if s >= len(operationName) {
 				return false
 			}
 			s++
@@ -106,16 +108,16 @@ func wildcardMatch(pat string, p int, str string, s int) bool {
 	}
 }
 
-func multiWildcardMatch(pat string, p int, str string, s int) bool {
-	switch safeCharAt(pat, p) {
+func multiWildcardMatch(pattern string, p int, operationName string, s int) bool {
+	switch safeCharAt(pattern, p) {
 	case 0:
 		return true
 	case '/':
 		p++
 	}
 	for {
-		if !normalMatch(pat, p, str, s) {
-			if s >= len(str) {
+		if !normalMatch(pattern, p, operationName, s) {
+			if s >= len(operationName) {
 				return false
 			}
 			s++

--- a/plugins/core/tracer_ignore.go
+++ b/plugins/core/tracer_ignore.go
@@ -1,0 +1,144 @@
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Apache Software Foundation (ASF) licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package core
+
+import (
+	"strings"
+)
+
+const (
+	PERIOD = "."
+	COLON  = ":"
+)
+
+func tracerIgnore(operationName string, ignoreSuffixList []string, ignorePath []string) bool {
+	return ignoreSuffix(operationName, ignoreSuffixList) || traceIgnorePath(operationName, ignorePath)
+}
+
+func ignoreSuffix(operationName string, ignoreSuffix []string) bool {
+	suffixIdx := strings.LastIndex(operationName, PERIOD)
+	if suffixIdx == -1 {
+		return false
+	}
+	for _, suffix := range ignoreSuffix {
+		if suffix == operationName[suffixIdx:] {
+			return true
+		}
+	}
+	return false
+}
+
+func traceIgnorePath(operationName string, ignorePath []string) bool {
+	op := strings.Index(operationName, COLON)
+	if op == -1 {
+		return false
+	}
+	operationName = operationName[op+1:]
+	for _, pattern := range ignorePath {
+		if normalMatch(pattern, 0, operationName, 0) {
+			return true
+		}
+	}
+	return false
+}
+
+func normalMatch(pat string, p int, str string, s int) bool {
+	for p < len(pat) {
+		pc := pat[p]
+		sc := safeCharAt(str, s)
+
+		if pc == '*' {
+			p++
+			if safeCharAt(pat, p) == '*' {
+				p++
+				return multiWildcardMatch(pat, p, str, s)
+			} else {
+				return wildcardMatch(pat, p, str, s)
+			}
+		}
+
+		if (pc == '?' && sc != 0 && sc != '/') || pc == sc {
+			s++
+			p++
+			continue
+		}
+		return false
+	}
+	return s == len(str)
+}
+
+func wildcardMatch(pat string, p int, str string, s int) bool {
+	pc := safeCharAt(pat, p)
+
+	if pc == 0 {
+		for {
+			sc := safeCharAt(str, s)
+			if sc == 0 {
+				return true
+			}
+			if sc == '/' {
+				return s == len(str)-1
+			}
+			s++
+		}
+	}
+
+	for {
+		sc := safeCharAt(str, s)
+		if sc == '/' {
+			if pc == sc {
+				return normalMatch(pat, p+1, str, s+1)
+			}
+			return false
+		}
+		if !normalMatch(pat, p, str, s) {
+			if s >= len(str) {
+				return false
+			}
+			s++
+			continue
+		}
+		return true
+	}
+}
+
+func multiWildcardMatch(pat string, p int, str string, s int) bool {
+	switch safeCharAt(pat, p) {
+	case 0:
+		return true
+	case '/':
+		p++
+	}
+	for {
+		if !normalMatch(pat, p, str, s) {
+			if s >= len(str) {
+				return false
+			}
+			s++
+			continue
+		}
+		return true
+	}
+}
+
+func safeCharAt(value string, index int) byte {
+	if index >= len(value) {
+		return 0
+	}
+	return value[index]
+}

--- a/plugins/core/tracer_ignore_test.go
+++ b/plugins/core/tracer_ignore_test.go
@@ -1,0 +1,69 @@
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Apache Software Foundation (ASF) licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package core
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTraceIgnorePath(t *testing.T) {
+	ignorePath := []string{"/health/*"}
+	assert.True(t, traceIgnorePath("GET:/health/apps", ignorePath))
+	assert.True(t, traceIgnorePath("GET:/health/", ignorePath))
+	assert.True(t, traceIgnorePath("GET:/health/apps/", ignorePath))
+
+	ignorePath = []string{"/health/**"}
+	assert.True(t, traceIgnorePath("GET:/health/apps/", ignorePath))
+
+	ignorePath = []string{"/health/*/"}
+	assert.True(t, traceIgnorePath("GET:/health/apps/", ignorePath))
+	assert.False(t, traceIgnorePath("GET:/health/", ignorePath))
+	assert.False(t, traceIgnorePath("GET:/health/apps/list", ignorePath))
+	assert.False(t, traceIgnorePath("GET:/health/test", ignorePath))
+
+	ignorePath = []string{"/health/**"}
+	assert.True(t, traceIgnorePath("GET:/health/", ignorePath))
+	assert.True(t, traceIgnorePath("GET:/health/apps/test", ignorePath))
+	assert.True(t, traceIgnorePath("GET:/health/apps/test/", ignorePath))
+
+	ignorePath = []string{"health/apps/?"}
+	assert.False(t, traceIgnorePath("GET:health/apps/list", ignorePath))
+	assert.False(t, traceIgnorePath("GET:health/apps/", ignorePath))
+	assert.True(t, traceIgnorePath("GET:health/apps/a", ignorePath))
+
+	ignorePath = []string{"health/**/lists"}
+	assert.True(t, traceIgnorePath("GET:health/apps/lists", ignorePath))
+	assert.True(t, traceIgnorePath("GET:health/apps/test/lists", ignorePath))
+	assert.False(t, traceIgnorePath("GET:health/apps/test/", ignorePath))
+	assert.False(t, traceIgnorePath("GET:health/apps/test", ignorePath))
+
+	ignorePath = []string{"health/**/test/**"}
+	assert.True(t, traceIgnorePath("GET:health/apps/test/list", ignorePath))
+	assert.True(t, traceIgnorePath("GET:health/apps/foo/test/list/bar", ignorePath))
+	assert.True(t, traceIgnorePath("GET:health/apps/foo/test/list/bar/", ignorePath))
+	assert.True(t, traceIgnorePath("GET:health/apps/test/list", ignorePath))
+	assert.True(t, traceIgnorePath("GET:health/test/list", ignorePath))
+
+	ignorePath = []string{"/health/**/b/**/*.txt", "abc/*"}
+	assert.True(t, traceIgnorePath("GET:/health/a/aa/aaa/b/bb/bbb/xxxxxx.txt", ignorePath))
+	assert.False(t, traceIgnorePath("GET:/health/a/aa/aaa/b/bb/bbb/xxxxxx", ignorePath))
+	assert.False(t, traceIgnorePath("GET:abc/foo/bar", ignorePath))
+	assert.True(t, traceIgnorePath("GET:abc/foo", ignorePath))
+}

--- a/plugins/core/tracer_ignore_test.go
+++ b/plugins/core/tracer_ignore_test.go
@@ -18,52 +18,64 @@
 package core
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
+func TestIgnoreSuffix(t *testing.T) {
+	ignoreSuffixStr := ".jpg,.jpeg,.js,.css,.png,.bmp,.gif,.ico,.mp3,.mp4,.html,.svg"
+	ignoreSuffixList := strings.Split(ignoreSuffixStr, ",")
+	assert.True(t, ignoreSuffix("GET:/favicon.ico", ignoreSuffixList))
+}
+
 func TestTraceIgnorePath(t *testing.T) {
 	ignorePath := []string{"/health/*"}
-	assert.True(t, traceIgnorePath("GET:/health/apps", ignorePath))
-	assert.True(t, traceIgnorePath("GET:/health/", ignorePath))
-	assert.True(t, traceIgnorePath("GET:/health/apps/", ignorePath))
+	assert.False(t, traceIgnorePath("", ignorePath))
+	assert.True(t, traceIgnorePath("/health/apps", ignorePath))
+	assert.True(t, traceIgnorePath("/health/", ignorePath))
+	assert.True(t, traceIgnorePath("/health/apps/", ignorePath))
 
 	ignorePath = []string{"/health/**"}
-	assert.True(t, traceIgnorePath("GET:/health/apps/", ignorePath))
+	assert.True(t, traceIgnorePath("/health/apps/", ignorePath))
+
+	ignorePath = []string{"/health/?"}
+	assert.True(t, traceIgnorePath("/health/a", ignorePath))
+	assert.False(t, traceIgnorePath("/health/ab", ignorePath))
 
 	ignorePath = []string{"/health/*/"}
-	assert.True(t, traceIgnorePath("GET:/health/apps/", ignorePath))
-	assert.False(t, traceIgnorePath("GET:/health/", ignorePath))
-	assert.False(t, traceIgnorePath("GET:/health/apps/list", ignorePath))
-	assert.False(t, traceIgnorePath("GET:/health/test", ignorePath))
+	assert.True(t, traceIgnorePath("/health/apps/", ignorePath))
+	assert.False(t, traceIgnorePath("/health/", ignorePath))
+	assert.False(t, traceIgnorePath("/health/apps/list", ignorePath))
+	assert.False(t, traceIgnorePath("/health/test", ignorePath))
 
 	ignorePath = []string{"/health/**"}
-	assert.True(t, traceIgnorePath("GET:/health/", ignorePath))
-	assert.True(t, traceIgnorePath("GET:/health/apps/test", ignorePath))
-	assert.True(t, traceIgnorePath("GET:/health/apps/test/", ignorePath))
+	assert.True(t, traceIgnorePath("/health/", ignorePath))
+	assert.True(t, traceIgnorePath("/health/apps/test", ignorePath))
+	assert.True(t, traceIgnorePath("/health/apps/test/", ignorePath))
 
 	ignorePath = []string{"health/apps/?"}
-	assert.False(t, traceIgnorePath("GET:health/apps/list", ignorePath))
-	assert.False(t, traceIgnorePath("GET:health/apps/", ignorePath))
-	assert.True(t, traceIgnorePath("GET:health/apps/a", ignorePath))
+	assert.False(t, traceIgnorePath("health/apps/list", ignorePath))
+	assert.False(t, traceIgnorePath("health/apps/", ignorePath))
+	assert.True(t, traceIgnorePath("health/apps/a", ignorePath))
 
 	ignorePath = []string{"health/**/lists"}
-	assert.True(t, traceIgnorePath("GET:health/apps/lists", ignorePath))
-	assert.True(t, traceIgnorePath("GET:health/apps/test/lists", ignorePath))
-	assert.False(t, traceIgnorePath("GET:health/apps/test/", ignorePath))
-	assert.False(t, traceIgnorePath("GET:health/apps/test", ignorePath))
+	assert.True(t, traceIgnorePath("health/apps/lists", ignorePath))
+	assert.True(t, traceIgnorePath("health/apps/test/lists", ignorePath))
+	assert.False(t, traceIgnorePath("health/apps/test/", ignorePath))
+	assert.False(t, traceIgnorePath("health/apps/test", ignorePath))
 
 	ignorePath = []string{"health/**/test/**"}
-	assert.True(t, traceIgnorePath("GET:health/apps/test/list", ignorePath))
-	assert.True(t, traceIgnorePath("GET:health/apps/foo/test/list/bar", ignorePath))
-	assert.True(t, traceIgnorePath("GET:health/apps/foo/test/list/bar/", ignorePath))
-	assert.True(t, traceIgnorePath("GET:health/apps/test/list", ignorePath))
-	assert.True(t, traceIgnorePath("GET:health/test/list", ignorePath))
+	assert.True(t, traceIgnorePath("health/apps/test/list", ignorePath))
+	assert.True(t, traceIgnorePath("health/apps/foo/test/list/bar", ignorePath))
+	assert.True(t, traceIgnorePath("health/apps/foo/test/list/bar/", ignorePath))
+	assert.True(t, traceIgnorePath("health/apps/test/list", ignorePath))
+	assert.True(t, traceIgnorePath("health/test/list", ignorePath))
 
 	ignorePath = []string{"/health/**/b/**/*.txt", "abc/*"}
-	assert.True(t, traceIgnorePath("GET:/health/a/aa/aaa/b/bb/bbb/xxxxxx.txt", ignorePath))
-	assert.False(t, traceIgnorePath("GET:/health/a/aa/aaa/b/bb/bbb/xxxxxx", ignorePath))
-	assert.False(t, traceIgnorePath("GET:abc/foo/bar", ignorePath))
-	assert.True(t, traceIgnorePath("GET:abc/foo", ignorePath))
+	assert.True(t, traceIgnorePath("/health/a/aa/aaa/b/bb/bbb/xxxxxx.txt", ignorePath))
+	assert.False(t, traceIgnorePath("/health/a/aa/aaa/b/bb/bbb/xxxxxx", ignorePath))
+	assert.False(t, traceIgnorePath("abc/foo/bar", ignorePath))
+	assert.True(t, traceIgnorePath("abc/foo", ignorePath))
 }

--- a/plugins/core/tracing.go
+++ b/plugins/core/tracing.go
@@ -20,7 +20,6 @@ package core
 import (
 	"reflect"
 	"runtime/debug"
-	"strings"
 
 	"github.com/pkg/errors"
 
@@ -230,7 +229,7 @@ func (t *Tracer) createNoop(operationName string) (*TracingContext, TracingSpan,
 	if !t.InitSuccess() || t.Reporter.ConnectionStatus() == reporter.ConnectionStatusDisconnect {
 		return nil, newNoopSpan(), true
 	}
-	if ignoreSuffixFilter(operationName, t.ignoreSuffix) {
+	if tracerIgnore(operationName, t.ignoreSuffix, t.traceIgnorePath) {
 		return nil, newNoopSpan(), true
 	}
 	ctx := getTracingContext()
@@ -340,17 +339,4 @@ func saveSpanToActiveIfNotError(ctx *TracingContext, span interface{}, err error
 	}
 	ctx.SaveActiveSpan(span.(TracingSpan))
 	SetGLS(ctx)
-}
-
-func ignoreSuffixFilter(operationName string, ignoreSuffix []string) bool {
-	suffixIdx := strings.LastIndex(operationName, ".")
-	if suffixIdx == -1 {
-		return false
-	}
-	for _, suffix := range ignoreSuffix {
-		if suffix == operationName[suffixIdx:] {
-			return true
-		}
-	}
-	return false
 }

--- a/tools/go-agent/config/agent.default.yaml
+++ b/tools/go-agent/config/agent.default.yaml
@@ -30,10 +30,13 @@ agent:
   correlation:
     max_key_count: ${SW_AGENT_CORRELATION_MAX_KEY_COUNT:3}
     max_value_size: ${SW_AGENT_CORRELATION_MAX_VALUE_SIZE:128}
-  # If the operation name of the first span is included in this set, this segment should be ignored.(multiple split by ",").
+  # If the suffix obtained by splitting the operation name by the last index of "." in this set, this segment should be ignored.(multiple split by ",").
   ignore_suffix: ${SW_AGENT_IGNORE_SUFFIX:.jpg,.jpeg,.js,.css,.png,.bmp,.gif,.ico,.mp3,.mp4,.html,.svg}
   # If the operation name of the first span is matching, this segment should be ignored.(multiple split by ",").
   # Matching rules follow Ant Path match style, like /path/*, /path/**, /path/?.
+  #       "/path/*" means matching any path that starts with "/path/".  
+  #       "/path/**" means matching any path that starts with "/path/" and includes its subpaths.
+  #       "/path/?" means matching any path that starts with "/path/" and has any single character as a wildcard.
   trace_ignore_path: ${SW_AGENT_TRACE_IGNORE_PATH:}
 
 reporter:

--- a/tools/go-agent/config/agent.default.yaml
+++ b/tools/go-agent/config/agent.default.yaml
@@ -30,8 +30,11 @@ agent:
   correlation:
     max_key_count: ${SW_AGENT_CORRELATION_MAX_KEY_COUNT:3}
     max_value_size: ${SW_AGENT_CORRELATION_MAX_VALUE_SIZE:128}
-  # If the operation name of the first span is included in this set, this segment should be ignored.(multiple split by ",")
+  # If the operation name of the first span is included in this set, this segment should be ignored.(multiple split by ",").
   ignore_suffix: ${SW_AGENT_IGNORE_SUFFIX:.jpg,.jpeg,.js,.css,.png,.bmp,.gif,.ico,.mp3,.mp4,.html,.svg}
+  # If the operation name of the first span is matching, this segment should be ignored.(multiple split by ",").
+  # Matching rules follow Ant Path match style, like /path/*, /path/**, /path/?.
+  trace_ignore_path: ${SW_AGENT_TRACE_IGNORE_PATH:}
 
 reporter:
   discard: ${SW_AGENT_REPORTER_DISCARD:false}

--- a/tools/go-agent/config/loader.go
+++ b/tools/go-agent/config/loader.go
@@ -51,6 +51,7 @@ type Agent struct {
 	Meter           Meter       `yaml:"meter"`
 	Correlation     Correlation `yaml:"correlation"`
 	IgnoreSuffix    StringValue `yaml:"ignore_suffix"`
+	TraceIgnorePath StringValue `yaml:"trace_ignore_path"`
 }
 
 type Reporter struct {

--- a/tools/go-agent/instrument/agentcore/instrument.go
+++ b/tools/go-agent/instrument/agentcore/instrument.go
@@ -163,7 +163,8 @@ func (t *Tracer) InitTracer(extend map[string]interface{}) {
 		MaxValueSize : {{.Config.Agent.Correlation.MaxValueSize.ToGoIntValue "loading the agent correlation maxValueSize error"}},
 	}
 	ignoreSuffixStr := {{.Config.Agent.IgnoreSuffix.ToGoStringValue}}
-	if err := t.Init(entity, rep, samp, logger, meterCollectInterval, correlation, ignoreSuffixStr); err != nil {
+	ignorePath := {{.Config.Agent.TraceIgnorePath.ToGoStringValue}}
+	if err := t.Init(entity, rep, samp, logger, meterCollectInterval, correlation, ignoreSuffixStr, ignorePath); err != nil {
 		t.Log.Errorf("cannot initialize the SkyWalking Tracer: %v", err)
 	}
 }`, struct {


### PR DESCRIPTION
### Summary

If the operation name of the first span is matching, this segment should be ignored.(multiple split by ","), matching rules follow Ant Path match style, like /path/*, /path/**, /path/?.