### PR TITLE
chore: enhance makefile

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,9 @@ Release Notes.
 * Support [Segmentio-Kafka](https://github.com/segmentio/kafka-go) MQ.
 * Support http headers collection for Gin
 
+#### Chore
+* Enhance the observability of makefile execution
+
 0.4.0
 ------------------
 #### Features


### PR DESCRIPTION
In the current PR, the makefile has been enhanced, mainly including the following two enhancements:

+ Add `$(LOG_TARGET)` to support printing make execution target information highlighting
+ Add `make help` command to help users more conveniently understand the TARGET allowed to be executed in make
like below:
```shell
[root@shy code]# make help

Usage:
  make <target>

General
  help             Display this help.

Golang
  test             Run E2E scenario tests
  lint             Run golangci-lint linter
  check            Run consistency checks
  build            Build skywalking-go agent binary
  release          Build skywalking-go agent release

Docker
  docker           Build docker images for skywalking-go agent and Push docker images to registry
```
