### PR TITLE
Add support for go-elasticsearch

### DIFF
--- a/.github/workflows/plugin-tests.yaml
+++ b/.github/workflows/plugin-tests.yaml
@@ -100,6 +100,7 @@ jobs:
           - amqp
           - pulsar
           - segmentio-kafka
+          - go-elasticsearchv8
     steps:
       - uses: actions/checkout@v2
         with:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,11 +6,12 @@ Release Notes.
 ------------------
 #### Features
 * Add support trace ignore.
+* Enhance the observability of makefile execution.
 
 #### Plugins
 * Support [Pulsar](https://github.com/apache/pulsar-client-go) MQ.
 * Support [Segmentio-Kafka](https://github.com/segmentio/kafka-go) MQ.
-* Support http headers collection for Gin
+* Support http headers collection for Gin.
 * Support higher versions of grpc.
 * Support [go-elasticsearchv8](https://github.com/elastic/go-elasticsearch) database client framework.
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,9 +12,7 @@ Release Notes.
 * Support [Segmentio-Kafka](https://github.com/segmentio/kafka-go) MQ.
 * Support http headers collection for Gin
 * Support higher versions of grpc.
-
-#### Chore
-* Enhance the observability of makefile execution
+* Support [go-elasticsearchv8](https://github.com/elastic/go-elasticsearch) database client framework.
 
 0.4.0
 ------------------

--- a/docs/en/agent/support-plugins.md
+++ b/docs/en/agent/support-plugins.md
@@ -25,6 +25,7 @@ metrics based on the tracing data.
   * `mongo`: [Mongo](https://github.com/mongodb/mongo-go-driver) tested v1.11.1 to v1.11.7.
   * `sql`: [Native SQL](https://pkg.go.dev/database/sql) tested go v1.17 to go v1.20.
     * [MySQL Driver](https://github.com/go-sql-driver/mysql) tested v1.4.0 to v1.7.1.
+  * `go-elasticsearchv8`: [go-elasticsearch](https://github.com/elastic/go-elasticsearch) tested v8.10.0 to v8.11.1.
 * Cache Client
   * `go-redisv9`: [go-redis](https://github.com/redis/go-redis) tested v9.0.3 to v9.0.5.
 * MQ Client

--- a/go.work
+++ b/go.work
@@ -27,6 +27,7 @@ use (
 	./plugins/amqp
 	./plugins/pulsar
 	./plugins/segmentio-kafka
+	./plugins/go-elasticsearchv8
 
 	./test/benchmark-codebase/consumer
 	./test/benchmark-codebase/provider
@@ -61,6 +62,7 @@ use (
 	./test/plugins/scenarios/amqp
 	./test/plugins/scenarios/pulsar
 	./test/plugins/scenarios/segmentio-kafka
+	./test/plugins/scenarios/go-elasticsearchv8
 
 	./tools/go-agent
 

--- a/plugins/core/tracer_ignore.go
+++ b/plugins/core/tracer_ignore.go
@@ -26,6 +26,9 @@ func tracerIgnore(operationName string, ignoreSuffixList, ignorePath []string) b
 }
 
 func ignoreSuffix(operationName string, ignoreSuffix []string) bool {
+	if len(ignoreSuffix) == 0 {
+		return false
+	}
 	suffixIdx := strings.LastIndex(operationName, ".")
 	if suffixIdx == -1 {
 		return false
@@ -39,6 +42,9 @@ func ignoreSuffix(operationName string, ignoreSuffix []string) bool {
 }
 
 func traceIgnorePath(operationName string, ignorePath []string) bool {
+	if len(ignorePath) == 0 {
+		return false
+	}
 	for _, pattern := range ignorePath {
 		if normalMatch(pattern, 0, operationName, 0) {
 			return true

--- a/plugins/go-elasticsearchv8/go.mod
+++ b/plugins/go-elasticsearchv8/go.mod
@@ -1,0 +1,8 @@
+module github.com/apache/skywalking-go/plugins/go-elasticsearchv8
+
+go 1.18
+
+require (
+	github.com/elastic/elastic-transport-go/v8 v8.3.0 // indirect
+	github.com/elastic/go-elasticsearch/v8 v8.11.1 // indirect
+)

--- a/plugins/go-elasticsearchv8/go.sum
+++ b/plugins/go-elasticsearchv8/go.sum
@@ -1,0 +1,4 @@
+github.com/elastic/elastic-transport-go/v8 v8.3.0 h1:DJGxovyQLXGr62e9nDMPSxRyWION0Bh6d9eCFBriiHo=
+github.com/elastic/elastic-transport-go/v8 v8.3.0/go.mod h1:87Tcz8IVNe6rVSLdBux1o/PEItLtyabHU3naC7IoqKI=
+github.com/elastic/go-elasticsearch/v8 v8.11.1 h1:1VgTgUTbpqQZ4uE+cPjkOvy/8aw1ZvKcU0ZUE5Cn1mc=
+github.com/elastic/go-elasticsearch/v8 v8.11.1/go.mod h1:GU1BJHO7WeamP7UhuElYwzzHtvf9SDmeVpSSy9+o6Qg=

--- a/plugins/go-elasticsearchv8/instrument.go
+++ b/plugins/go-elasticsearchv8/instrument.go
@@ -1,0 +1,67 @@
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Apache Software Foundation (ASF) licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package goelasticsearchv8
+
+import (
+	"embed"
+	"strings"
+
+	"github.com/apache/skywalking-go/plugins/core/instrument"
+)
+
+//go:embed *
+var fs embed.FS
+
+//skywalking:nocopy
+type Instrument struct {
+}
+
+func NewInstrument() *Instrument {
+	return &Instrument{}
+}
+
+func (i *Instrument) Name() string {
+	return "go-elasticsearchv8"
+}
+
+func (i *Instrument) BasePackage() string {
+	return "github.com/elastic/go-elasticsearch/v8"
+}
+
+func (i *Instrument) VersionChecker(version string) bool {
+	return strings.HasPrefix(version, "v8.")
+}
+
+func (i *Instrument) Points() []*instrument.Point {
+	return []*instrument.Point{
+		{
+			PackageName: "elasticsearch",
+			At: instrument.NewMethodEnhance("*BaseClient", "Perform",
+				instrument.WithArgsCount(1),
+				instrument.WithArgType(0, "*http.Request"),
+				instrument.WithResultCount(2),
+				instrument.WithResultType(0, "*http.Response"),
+				instrument.WithResultType(1, "error")),
+			Interceptor: "ESV8Interceptor",
+		},
+	}
+}
+
+func (i *Instrument) FS() *embed.FS {
+	return &fs
+}

--- a/plugins/go-elasticsearchv8/intercepter.go
+++ b/plugins/go-elasticsearchv8/intercepter.go
@@ -41,7 +41,6 @@ func (es *ESV8Interceptor) BeforeInvoke(invocation operator.Invocation) error {
 	url := strings.Join(addresses, ",")
 	req := invocation.Args()[0].(*http.Request)
 	span, err := tracing.CreateExitSpan("Elasticsearch/"+req.Method, url, func(headerKey, headerValue string) error {
-		req.Header.Add(headerKey, headerValue)
 		return nil
 	},
 		tracing.WithLayer(tracing.SpanLayerDatabase),

--- a/plugins/http/client_intercepter.go
+++ b/plugins/http/client_intercepter.go
@@ -30,9 +30,6 @@ type ClientInterceptor struct {
 
 func (h *ClientInterceptor) BeforeInvoke(invocation operator.Invocation) error {
 	request := invocation.Args()[0].(*http.Request)
-	if request.Host == "" {
-		return nil
-	}
 	s, err := tracing.CreateExitSpan(fmt.Sprintf("%s:%s", request.Method, request.URL.Path), request.Host, func(headerKey, headerValue string) error {
 		request.Header.Add(headerKey, headerValue)
 		return nil

--- a/test/plugins/scenarios/amqp/config/excepted.yml
+++ b/test/plugins/scenarios/amqp/config/excepted.yml
@@ -20,23 +20,6 @@ segmentItems:
     segments:
       - segmentId: not null
         spans:
-          - operationName: GET:/health
-            parentSpanId: -1
-            spanId: 0
-            spanLayer: Http
-            startTime: nq 0
-            endTime: nq 0
-            componentId: 5004
-            isError: false
-            spanType: Entry
-            peer: ''
-            skipAnalysis: false
-            tags:
-              - { key: http.method, value: GET }
-              - { key: url, value: 'service:8080/health' }
-              - { key: status_code, value: '200' }
-      - segmentId: not null
-        spans:
           - operationName: AMQP/sw-queue-1/Producer
             parentSpanId: 0
             spanId: 1

--- a/test/plugins/scenarios/amqp/main.go
+++ b/test/plugins/scenarios/amqp/main.go
@@ -77,7 +77,6 @@ func main() {
 	if err != nil {
 		log.Fatalf("client start error: %v \n", err)
 	}
-	select {}
 }
 
 func testSimpleConsumer(client RabbitClient) error {

--- a/test/plugins/scenarios/go-elasticsearchv8/bin/startup.sh
+++ b/test/plugins/scenarios/go-elasticsearchv8/bin/startup.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+home="$(cd "$(dirname $0)"; pwd)"
+go build ${GO_BUILD_OPTS} -o go-elasticsearchv8
+
+./go-elasticsearchv8

--- a/test/plugins/scenarios/go-elasticsearchv8/config/elasticsearch.yml
+++ b/test/plugins/scenarios/go-elasticsearchv8/config/elasticsearch.yml
@@ -1,0 +1,22 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cluster.name: "sw-es-cluster"
+discovery.type: "single-node"
+network.host: 0.0.0.0
+ingest.geoip.downloader.enabled: false
+xpack.security.enabled: false
+xpack.security.enrollment.enabled: false

--- a/test/plugins/scenarios/go-elasticsearchv8/config/excepted.yml
+++ b/test/plugins/scenarios/go-elasticsearchv8/config/excepted.yml
@@ -1,0 +1,99 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+segmentItems:
+  - serviceName: go-elasticsearchv8
+    segmentSize: ge 1
+    segments:
+      - segmentId: not null
+        spans:
+          - operationName: Elasticsearch/PUT
+            parentSpanId: 0
+            spanId: 1
+            spanLayer: Database
+            startTime: nq 0
+            endTime: nq 0
+            componentId: 47
+            isError: false
+            spanType: Exit
+            peer: http://elasticsearch:9200
+            skipAnalysis: false
+            tags:
+              - { key: db.type, value: Elasticsearch }
+              - { key: db.statement, value: not null }
+              - { key: status_code, value: '200' }
+          - operationName: Elasticsearch/PUT
+            parentSpanId: 0
+            spanId: 2
+            spanLayer: Database
+            startTime: nq 0
+            endTime: nq 0
+            componentId: 47
+            isError: false
+            spanType: Exit
+            peer: http://elasticsearch:9200
+            skipAnalysis: false
+            tags:
+              - { key: db.type, value: Elasticsearch }
+              - { key: db.statement, value: not null }
+              - { key: status_code, value: '201' }
+          - operationName: Elasticsearch/GET
+            parentSpanId: 0
+            spanId: 3
+            spanLayer: Database
+            startTime: nq 0
+            endTime: nq 0
+            componentId: 47
+            isError: false
+            spanType: Exit
+            peer: http://elasticsearch:9200
+            skipAnalysis: false
+            tags:
+              - { key: db.type, value: Elasticsearch }
+              - { key: db.statement, value: not null }
+              - { key: status_code, value: '200' }
+          - operationName: Elasticsearch/POST
+            parentSpanId: 0
+            spanId: 4
+            spanLayer: Database
+            startTime: nq 0
+            endTime: nq 0
+            componentId: 47
+            isError: false
+            spanType: Exit
+            peer: http://elasticsearch:9200
+            skipAnalysis: false
+            tags:
+              - { key: db.type, value: Elasticsearch }
+              - { key: db.statement, value: not null }
+              - { key: status_code, value: '200' }
+          - operationName: GET:/execute
+            parentSpanId: -1
+            spanId: 0
+            spanLayer: Http
+            startTime: nq 0
+            endTime: nq 0
+            componentId: 5004
+            isError: false
+            spanType: Entry
+            peer: ''
+            skipAnalysis: false
+            tags:
+              - { key: http.method, value: GET }
+              - { key: url, value: 'service:8080/execute' }
+              - { key: status_code, value: '200' }
+meterItems: [ ]
+logItems: [ ]

--- a/test/plugins/scenarios/go-elasticsearchv8/config/excepted.yml
+++ b/test/plugins/scenarios/go-elasticsearchv8/config/excepted.yml
@@ -33,7 +33,7 @@ segmentItems:
             skipAnalysis: false
             tags:
               - { key: db.type, value: Elasticsearch }
-              - { key: db.statement, value: not null }
+              - { key: db.statement, value: sw-index }
               - { key: status_code, value: '200' }
           - operationName: Elasticsearch/PUT
             parentSpanId: 0
@@ -48,7 +48,7 @@ segmentItems:
             skipAnalysis: false
             tags:
               - { key: db.type, value: Elasticsearch }
-              - { key: db.statement, value: not null }
+              - { key: db.statement, value: sw-index/_doc/1 }
               - { key: status_code, value: '201' }
           - operationName: Elasticsearch/GET
             parentSpanId: 0
@@ -63,7 +63,7 @@ segmentItems:
             skipAnalysis: false
             tags:
               - { key: db.type, value: Elasticsearch }
-              - { key: db.statement, value: not null }
+              - { key: db.statement, value: sw-index/_doc/1 }
               - { key: status_code, value: '200' }
           - operationName: Elasticsearch/POST
             parentSpanId: 0
@@ -78,7 +78,7 @@ segmentItems:
             skipAnalysis: false
             tags:
               - { key: db.type, value: Elasticsearch }
-              - { key: db.statement, value: not null }
+              - { key: db.statement, value: sw-index/_search }
               - { key: status_code, value: '200' }
           - operationName: GET:/execute
             parentSpanId: -1

--- a/test/plugins/scenarios/go-elasticsearchv8/go.mod
+++ b/test/plugins/scenarios/go-elasticsearchv8/go.mod
@@ -1,0 +1,8 @@
+module test/plugins/scenarios/go-elasticsearchv8
+
+go 1.18
+
+require (
+	github.com/elastic/elastic-transport-go/v8 v8.3.0 // indirect
+	github.com/elastic/go-elasticsearch/v8 v8.11.1 // indirect
+)

--- a/test/plugins/scenarios/go-elasticsearchv8/go.sum
+++ b/test/plugins/scenarios/go-elasticsearchv8/go.sum
@@ -1,0 +1,4 @@
+github.com/elastic/elastic-transport-go/v8 v8.3.0 h1:DJGxovyQLXGr62e9nDMPSxRyWION0Bh6d9eCFBriiHo=
+github.com/elastic/elastic-transport-go/v8 v8.3.0/go.mod h1:87Tcz8IVNe6rVSLdBux1o/PEItLtyabHU3naC7IoqKI=
+github.com/elastic/go-elasticsearch/v8 v8.11.1 h1:1VgTgUTbpqQZ4uE+cPjkOvy/8aw1ZvKcU0ZUE5Cn1mc=
+github.com/elastic/go-elasticsearch/v8 v8.11.1/go.mod h1:GU1BJHO7WeamP7UhuElYwzzHtvf9SDmeVpSSy9+o6Qg=

--- a/test/plugins/scenarios/go-elasticsearchv8/main.go
+++ b/test/plugins/scenarios/go-elasticsearchv8/main.go
@@ -1,0 +1,137 @@
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Apache Software Foundation (ASF) licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package main
+
+import (
+	"context"
+
+	"log"
+	"net/http"
+	"strconv"
+
+	"github.com/elastic/go-elasticsearch/v8"
+	"github.com/elastic/go-elasticsearch/v8/typedapi/core/search"
+	"github.com/elastic/go-elasticsearch/v8/typedapi/types"
+
+	_ "github.com/apache/skywalking-go"
+)
+
+type testFunc func() error
+
+var (
+	client    *elasticsearch.TypedClient
+	url       = "http://elasticsearch:9200"
+	ctx       = context.Background()
+	indexName = "sw-index"
+)
+
+type SwDoc struct {
+	ID     int64  `json:"id"`
+	Simple string `json:"simple"`
+	Love   string `json:"love"`
+}
+
+func main() {
+	cfg := elasticsearch.Config{
+		Addresses: []string{url},
+	}
+	var err error
+	client, err = elasticsearch.NewTypedClient(cfg)
+	if err != nil {
+		log.Fatalf("connect to elasticsearch error: %v \n", err)
+	}
+	http.HandleFunc("/execute", executeHandler)
+	http.HandleFunc("/health", func(writer http.ResponseWriter, request *http.Request) {
+		writer.WriteHeader(http.StatusOK)
+	})
+	_ = http.ListenAndServe(":8080", nil)
+}
+
+func executeHandler(w http.ResponseWriter, r *http.Request) {
+	testCases := []struct {
+		name string
+		fn   testFunc
+	}{
+		{"createIndex", createIndex},
+		{"indexDocument", indexDocument},
+		{"getDocument", getDocument},
+		{"searchDocument", searchDocument},
+	}
+
+	for _, test := range testCases {
+		log.Printf("excute test case %s", test.name)
+		if err := test.fn(); err != nil {
+			log.Fatalf("test case %s failed: %v", test.name, err)
+		}
+	}
+}
+
+func createIndex() error {
+	_, err := client.Indices.
+		Create(indexName).
+		Do(ctx)
+	if err != nil {
+		log.Fatalf("create index failed, err:%v\n", err)
+		return err
+	}
+	return nil
+}
+
+func indexDocument() error {
+	simpleLove := SwDoc{
+		ID:     1,
+		Simple: "Just Simple",
+		Love:   "Just Love",
+	}
+	_, err := client.Index(indexName).
+		Id(strconv.FormatInt(simpleLove.ID, 10)).
+		Document(simpleLove).
+		Do(ctx)
+	if err != nil {
+		log.Fatalf("indexing document failed, err:%v\n", err)
+		return err
+	}
+	return nil
+}
+
+func getDocument() error {
+	_, err := client.Get(indexName, "1").
+		Do(context.Background())
+	if err != nil {
+		log.Printf("get document by id failed, err:%v\n", err)
+		return err
+	}
+	return nil
+}
+
+func searchDocument() error {
+	_, err := client.Search().
+		Index(indexName).
+		Request(&search.Request{
+			Query: &types.Query{
+				Match: map[string]types.MatchQuery{
+					"love": {Query: "Just Love"},
+				},
+			},
+		}).Do(ctx)
+	if err != nil {
+		log.Printf("search document failed, err:%v\n", err)
+		return err
+	}
+	return nil
+}

--- a/test/plugins/scenarios/go-elasticsearchv8/plugin.yml
+++ b/test/plugins/scenarios/go-elasticsearchv8/plugin.yml
@@ -1,0 +1,35 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+entry-service: http://${HTTP_HOST}:${HTTP_PORT}/execute
+health-checker: http://${HTTP_HOST}:${HTTP_PORT}/health
+start-script: ./bin/startup.sh
+framework: github.com/elastic/go-elasticsearch
+export-port: 8080
+support-version:
+  - go: 1.18
+    framework:
+      - v8.11.1
+      - v8.11.0
+      - v8.10.0
+dependencies:
+  elasticsearch:
+    image: elasticsearch:8.13.4
+    hostname: elasticsearch
+    ports:
+      - 9200
+    volumes:
+      - ./config/elasticsearch.yml:/usr/share/elasticsearch/config/elasticsearch.yml

--- a/test/plugins/scenarios/grpc/config/excepted.yml
+++ b/test/plugins/scenarios/grpc/config/excepted.yml
@@ -20,23 +20,6 @@ segmentItems:
     segments:
       - segmentId: not null
         spans:
-          - operationName: GET:/health
-            parentSpanId: -1
-            spanId: 0
-            spanLayer: Http
-            startTime: nq 0
-            endTime: nq 0
-            componentId: 5004
-            isError: false
-            spanType: Entry
-            peer: ''
-            skipAnalysis: false
-            tags:
-              - {key: http.method, value: GET}
-              - {key: url, value: 'service:8080/health'}
-              - {key: status_code, value: '200'}
-      - segmentId: not null
-        spans:
           - operationName: api.Echo.UnaryEcho/Client/Request/SendMsg
             parentSpanId: 1
             spanId: 2

--- a/test/plugins/scenarios/rocketmq/config/excepted.yml
+++ b/test/plugins/scenarios/rocketmq/config/excepted.yml
@@ -20,23 +20,6 @@ segmentItems:
     segments:
       - segmentId: not null
         spans:
-          - operationName: GET:/health
-            parentSpanId: -1
-            spanId: 0
-            spanLayer: Http
-            startTime: nq 0
-            endTime: nq 0
-            componentId: 5004
-            isError: false
-            spanType: Entry
-            peer: ''
-            skipAnalysis: false
-            tags:
-              - { key: http.method, value: GET }
-              - { key: url, value: 'service:8080/health' }
-              - { key: status_code, value: '200' }
-      - segmentId: not null
-        spans:
           - operationName: RocketMQ/sw-topic/Producer
             parentSpanId: 0
             spanId: 1

--- a/test/plugins/scenarios/trace-activation/config/excepted.yml
+++ b/test/plugins/scenarios/trace-activation/config/excepted.yml
@@ -20,23 +20,6 @@ segmentItems:
     segments:
       - segmentId: not null
         spans:
-          - operationName: GET:/health
-            parentSpanId: -1
-            spanId: 0
-            spanLayer: Http
-            startTime: nq 0
-            endTime: nq 0
-            componentId: 5004
-            isError: false
-            spanType: Entry
-            peer: ''
-            skipAnalysis: false
-            tags:
-              - {key: http.method, value: GET}
-              - {key: url, value: 'service:8080/health'}
-              - {key: status_code, value: '200'}
-      - segmentId: not null
-        spans:
           - operationName: testSetCorrelation
             parentSpanId: 0
             spanId: 1

--- a/tools/go-agent/instrument/plugins/register.go
+++ b/tools/go-agent/instrument/plugins/register.go
@@ -27,6 +27,7 @@ import (
 	fasthttp_router "github.com/apache/skywalking-go/plugins/fasthttp/router"
 	"github.com/apache/skywalking-go/plugins/fiber"
 	"github.com/apache/skywalking-go/plugins/gin"
+	goelasticsearchv8 "github.com/apache/skywalking-go/plugins/go-elasticsearchv8"
 	goredisv9 "github.com/apache/skywalking-go/plugins/go-redisv9"
 	"github.com/apache/skywalking-go/plugins/go-restfulv3"
 	gorm_entry "github.com/apache/skywalking-go/plugins/gorm/entry"
@@ -68,6 +69,7 @@ func init() {
 	registerFramework(amqp.NewInstrument())
 	registerFramework(pulsar.NewInstrument())
 	registerFramework(segmentiokafka.NewInstrument())
+	registerFramework(goelasticsearchv8.NewInstrument())
 
 	// fasthttp related instruments
 	registerFramework(fasthttp_client.NewInstrument())

--- a/tools/go-agent/instrument/plugins/templates/method_intercept_after.tmpl
+++ b/tools/go-agent/instrument/plugins/templates/method_intercept_after.tmpl
@@ -1,7 +1,6 @@
 defer func() {
 	if r := recover(); r != nil {
 		// log error
-		// fmt.Printf("error: %v", r)
 		log.Errorf("execute interceptor after invoke error, instrument name: %s, interceptor name: %s, function ID: %s, error: %v, stack: %s",
 		    "{{.InstrumentName}}", "{{.InterceptorDefineName}}", "{{.FuncID}}", r, tracing.DebugStack())
 	}


### PR DESCRIPTION
### Summary

[go-elasticsearch](https://github.com/elastic/go-elasticsearch) is the official Go client for Elasticsearch.