### PR TITLE
fix: when not route is found, the gin operation name is "http.Method:", example: "GET:".

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,7 @@ Release Notes.
 
 ### Bug Fixes
 * Fix panic error when root span finished.
+* Fix when not route is found, the gin operation name is "http.Method:", example: "GET:".
 
 0.4.0
 ------------------

--- a/plugins/gin/intercepter.go
+++ b/plugins/gin/intercepter.go
@@ -36,8 +36,12 @@ func (h *ContextInterceptor) BeforeInvoke(invocation operator.Invocation) error 
 		return nil
 	}
 	context := invocation.CallerInstance().(*gin.Context)
+	fullPath := context.FullPath()
+	if fullPath == "" {
+		fullPath = context.Request.URL.Path
+	}
 	s, err := tracing.CreateEntrySpan(
-		fmt.Sprintf("%s:%s", context.Request.Method, context.FullPath()), func(headerKey string) (string, error) {
+		fmt.Sprintf("%s:%s", context.Request.Method, fullPath), func(headerKey string) (string, error) {
 			return context.Request.Header.Get(headerKey), nil
 		},
 		tracing.WithLayer(tracing.SpanLayerHTTP),

--- a/test/plugins/scenarios/gin/config/excepted.yml
+++ b/test/plugins/scenarios/gin/config/excepted.yml
@@ -63,21 +63,6 @@ segmentItems:
                  parentService: gin, traceId: not null}
       - segmentId: not null
         spans:
-          - operationName: GET:/notFound
-            parentSpanId: 0
-            spanId: 1
-            spanLayer: Http
-            startTime: gt 0
-            endTime: gt 0
-            componentId: 5005
-            isError: false
-            spanType: Exit
-            peer: localhost:8080
-            skipAnalysis: false
-            tags:
-              - {key: http.method, value: GET}
-              - {key: url, value: 'localhost:8080/notFound'}
-              - {key: status_code, value: '404'}
           - operationName: GET:/provider
             parentSpanId: 0
             spanId: 1
@@ -93,6 +78,21 @@ segmentItems:
               - {key: http.method, value: GET}
               - {key: url, value: 'localhost:8080/provider'}
               - {key: status_code, value: '200'}
+          - operationName: GET:/notFound
+            parentSpanId: 0
+            spanId: 1
+            spanLayer: Http
+            startTime: gt 0
+            endTime: gt 0
+            componentId: 5005
+            isError: false
+            spanType: Exit
+            peer: localhost:8080
+            skipAnalysis: false
+            tags:
+              - {key: http.method, value: GET}
+              - {key: url, value: 'localhost:8080/notFound'}
+              - {key: status_code, value: '404'}
           - operationName: GET:/consumer
             parentSpanId: -1
             spanId: 0

--- a/test/plugins/scenarios/gin/config/excepted.yml
+++ b/test/plugins/scenarios/gin/config/excepted.yml
@@ -59,7 +59,7 @@ segmentItems:
               - {key: status_code, value: '404'}
             refs:
               - {parentEndpoint: 'GET:/consumer', networkAddress: 'localhost:8080', refType: CrossProcess,
-                 parentSpanId: 1, parentTraceSegmentId: not null, parentServiceInstance: not null,
+                 parentSpanId: 2, parentTraceSegmentId: not null, parentServiceInstance: not null,
                  parentService: gin, traceId: not null}
       - segmentId: not null
         spans:

--- a/test/plugins/scenarios/gin/config/excepted.yml
+++ b/test/plugins/scenarios/gin/config/excepted.yml
@@ -20,27 +20,6 @@ segmentItems:
     segments:
       - segmentId: not null
         spans:
-          - operationName: GET:/notFound
-            parentSpanId: -1
-            spanId: 0
-            spanLayer: Http
-            startTime: nq 0
-            endTime: nq 0
-            componentId: 5006
-            isError: false
-            spanType: Entry
-            peer: ''
-            skipAnalysis: false
-            tags:
-              - {key: http.method, value: GET}
-              - {key: url, value: 'localhost:8080/notFound'}
-              - {key: status_code, value: '404'}
-            refs:
-              - {parentEndpoint: 'GET:/consumer', networkAddress: 'localhost:8080', refType: CrossProcess,
-                 parentSpanId: 1, parentTraceSegmentId: not null, parentServiceInstance: not null,
-                 parentService: gin, traceId: not null}
-      - segmentId: not null
-        spans:
           - operationName: GET:/provider
             parentSpanId: -1
             spanId: 0
@@ -57,6 +36,27 @@ segmentItems:
               - {key: url, value: 'localhost:8080/provider'}
               - {key: http.headers, value: "h1=h1-value\nh2=h2"}
               - {key: status_code, value: '200'}
+            refs:
+              - {parentEndpoint: 'GET:/consumer', networkAddress: 'localhost:8080', refType: CrossProcess,
+                 parentSpanId: 1, parentTraceSegmentId: not null, parentServiceInstance: not null,
+                 parentService: gin, traceId: not null}
+      - segmentId: not null
+        spans:
+          - operationName: GET:/notFound
+            parentSpanId: -1
+            spanId: 0
+            spanLayer: Http
+            startTime: nq 0
+            endTime: nq 0
+            componentId: 5006
+            isError: false
+            spanType: Entry
+            peer: ''
+            skipAnalysis: false
+            tags:
+              - {key: http.method, value: GET}
+              - {key: url, value: 'localhost:8080/notFound'}
+              - {key: status_code, value: '404'}
             refs:
               - {parentEndpoint: 'GET:/consumer', networkAddress: 'localhost:8080', refType: CrossProcess,
                  parentSpanId: 1, parentTraceSegmentId: not null, parentServiceInstance: not null,
@@ -80,7 +80,7 @@ segmentItems:
               - {key: status_code, value: '200'}
           - operationName: GET:/notFound
             parentSpanId: 0
-            spanId: 1
+            spanId: 2
             spanLayer: Http
             startTime: gt 0
             endTime: gt 0

--- a/test/plugins/scenarios/gin/config/excepted.yml
+++ b/test/plugins/scenarios/gin/config/excepted.yml
@@ -20,6 +20,27 @@ segmentItems:
     segments:
       - segmentId: not null
         spans:
+          - operationName: GET:/notFound
+            parentSpanId: -1
+            spanId: 0
+            spanLayer: Http
+            startTime: nq 0
+            endTime: nq 0
+            componentId: 5006
+            isError: false
+            spanType: Entry
+            peer: ''
+            skipAnalysis: false
+            tags:
+              - {key: http.method, value: GET}
+              - {key: url, value: 'localhost:8080/notFound'}
+              - {key: status_code, value: '404'}
+            refs:
+              - {parentEndpoint: 'GET:/consumer', networkAddress: 'localhost:8080', refType: CrossProcess,
+                 parentSpanId: 1, parentTraceSegmentId: not null, parentServiceInstance: not null,
+                 parentService: gin, traceId: not null}
+      - segmentId: not null
+        spans:
           - operationName: GET:/provider
             parentSpanId: -1
             spanId: 0
@@ -42,6 +63,21 @@ segmentItems:
                  parentService: gin, traceId: not null}
       - segmentId: not null
         spans:
+          - operationName: GET:/notFound
+            parentSpanId: 0
+            spanId: 1
+            spanLayer: Http
+            startTime: gt 0
+            endTime: gt 0
+            componentId: 5005
+            isError: false
+            spanType: Exit
+            peer: localhost:8080
+            skipAnalysis: false
+            tags:
+              - {key: http.method, value: GET}
+              - {key: url, value: 'localhost:8080/notFound'}
+              - {key: status_code, value: '404'}
           - operationName: GET:/provider
             parentSpanId: 0
             spanId: 1

--- a/test/plugins/scenarios/gin/main.go
+++ b/test/plugins/scenarios/gin/main.go
@@ -55,6 +55,20 @@ func main() {
 			context.Status(http.StatusInternalServerError)
 			return
 		}
+
+		notFoundRequest, err := http.NewRequest(http.MethodGet, "http://localhost:8080/notFound", nil)
+		if err != nil {
+			log.Print(err)
+			context.Status(http.StatusInternalServerError)
+			return
+		}
+		_, err = client.Do(notFoundRequest)
+		if err != nil {
+			log.Print(err)
+			context.Status(http.StatusInternalServerError)
+			return
+		}
+
 		context.String(200, string(body))
 	})
 


### PR DESCRIPTION
fix: when not route is found, the gin operation name is "http.Method:", example: "GET:".