### PR TITLE
api: add log,metric,span feat to api

### DIFF
--- a/toolkit/log/api.go
+++ b/toolkit/log/api.go
@@ -1,3 +1,20 @@
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Apache Software Foundation (ASF) licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package log
 
 // Debug logs a message at DebugLevel

--- a/toolkit/log/api.go
+++ b/toolkit/log/api.go
@@ -1,0 +1,20 @@
+package log
+
+// Debug logs a message at DebugLevel
+func Debug(msg string, keyValues ...string) {
+
+}
+
+// Info logs a message at InfoLevel
+func Info(msg string, keyValues ...string) {
+
+}
+
+// Warn logs a message at DebugLevel
+func Warn(msg string, keyValues ...string) {
+
+}
+
+// Error logs a message at ErrorLevel
+func Error(msg string, keyValues ...string) {
+}

--- a/toolkit/metric/api.go
+++ b/toolkit/metric/api.go
@@ -18,16 +18,16 @@
 package metric
 
 // NewCounter creates a new counter metrics.
-func NewCounter(name string, opt ...meterOpt) *CounterRef {
+func NewCounter(name string, opt ...MeterOpt) *CounterRef {
 	return &CounterRef{}
 }
 
 // NewGauge creates a new gauge metrics.
-func NewGauge(name string, watcher func() float64, opts ...meterOpt) *GaugeRef {
+func NewGauge(name string, watcher func() float64, opts ...MeterOpt) *GaugeRef {
 	return &GaugeRef{}
 }
 
 // NewHistogram creates a new histogram metrics.
-func NewHistogram(name string, steps []float64, opts ...meterOpt) *Histogram {
+func NewHistogram(name string, steps []float64, opts ...MeterOpt) *Histogram {
 	return &Histogram{}
 }

--- a/toolkit/metric/api.go
+++ b/toolkit/metric/api.go
@@ -1,3 +1,20 @@
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Apache Software Foundation (ASF) licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package metric
 
 // NewCounter creates a new counter metrics.

--- a/toolkit/metric/api.go
+++ b/toolkit/metric/api.go
@@ -1,0 +1,16 @@
+package metric
+
+// NewCounter creates a new counter metrics.
+func NewCounter(name string, opt ...meterOpt) *CounterRef {
+	return &CounterRef{}
+}
+
+// NewGauge creates a new gauge metrics.
+func NewGauge(name string, watcher func() float64, opts ...meterOpt) *GaugeRef {
+	return &GaugeRef{}
+}
+
+// NewHistogram creates a new histogram metrics.
+func NewHistogram(name string, steps []float64, opts ...meterOpt) *Histogram {
+	return &Histogram{}
+}

--- a/toolkit/metric/metrics.go
+++ b/toolkit/metric/metrics.go
@@ -1,3 +1,20 @@
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Apache Software Foundation (ASF) licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package metric
 
 type CounterRef struct{}

--- a/toolkit/metric/metrics.go
+++ b/toolkit/metric/metrics.go
@@ -1,0 +1,40 @@
+package metric
+
+type CounterRef struct{}
+
+// Get returns the current value of the counter.
+func (c *CounterRef) Get() float64 {
+	return -1
+}
+
+// Inc increments the counter with value.
+func (c *CounterRef) Inc(val float64) {}
+
+type GaugeRef struct {
+}
+
+// Get returns the current value of the gauge.
+func (g *GaugeRef) Get() float64 {
+	return -1
+}
+
+type Histogram struct {
+}
+
+// Observe find the value associate bucket and add 1.
+func (h *Histogram) Observe(val float64) {
+
+}
+
+// ObserveWithCount find the value associate bucket and add specific count.
+func (h *Histogram) ObserveWithCount(val float64, count int64) {
+
+}
+
+type meterOpt struct {
+}
+
+// WithLabels Add labels for metric
+func WithLabels(key, val string) meterOpt {
+	return meterOpt{}
+}

--- a/toolkit/metric/metrics.go
+++ b/toolkit/metric/metrics.go
@@ -48,10 +48,10 @@ func (h *Histogram) ObserveWithCount(val float64, count int64) {
 
 }
 
-type meterOpt struct {
+type MeterOpt struct {
 }
 
 // WithLabels Add labels for metric
-func WithLabels(key, val string) meterOpt {
-	return meterOpt{}
+func WithLabels(key, val string) MeterOpt {
+	return MeterOpt{}
 }

--- a/toolkit/trace/span.go
+++ b/toolkit/trace/span.go
@@ -17,6 +17,22 @@
 
 package trace
 
+type EventType string
+
+const (
+	// DebugEventType Indicates the event type is "debug"
+	DebugEventType EventType = "debug"
+
+	// InfoEventType Indicates the event type is "info"
+	InfoEventType EventType = "info"
+
+	// WarnEventType Indicates the event type is "warn"
+	WarnEventType EventType = "warn"
+
+	// ErrorEventType Indicates the event type is "error"
+	ErrorEventType EventType = "error"
+)
+
 func (*SpanRef) PrepareAsync() {
 }
 
@@ -28,4 +44,8 @@ func (*SpanRef) SetTag(key string, value string) {
 }
 
 func (*SpanRef) AddLog(...string) {
+}
+
+// AddEvent Add an event of the specified type to SpanRef.
+func (*SpanRef) AddEvent(et EventType, event string) {
 }


### PR DESCRIPTION
Current PR is used to design the `toolkit` API, which mainly designs three aspects: trace, metric, log

+ trace: supports attaching events to spans.

+ log: supports manually calling logs

+ metric: supports manually building commonly used metrics