### PR TITLE
Fix wrong docker image name and `-version` command

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@ Release Notes.
 #### Plugins
 
 #### Bug Fixes
+* Fix wrong docker image name and `-version` command.
 
 #### Issues and PR
 - All issues are [here](https://github.com/apache/skywalking/milestone/219?closed=1)

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ GO_TEST_LDFLAGS =
 REPODIR := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))/
 LINT_FILE_PATH = $(REPODIR).golangci.yml
 
-VERSION_FILE=VERSION
+VERSION_FILE=$(REPODIR)VERSION
 
 SHELL = /bin/bash
 
@@ -40,6 +40,8 @@ GIT_VERSION := $(shell git rev-parse --short HEAD)
 ifeq ($(strip $(GIT_VERSION)),)
     GIT_VERSION = $(shell grep gitCommit $(VERSION_FILE) | awk -F ': ' '{print $$2}')
 endif
+
+VERSION ?= $(GIT_VERSION)
 
 LOG_TARGET = echo -e "\033[0;32m===========> Running $@ ... \033[0m"
 
@@ -146,16 +148,18 @@ docker.push.%: LOAD_OR_PUSH = --push
 
 .PHONY: $(base.all)
 $(base.all:%=docker.%): BASE_IMAGE=$($(base.each:docker.%=base.image.%))
-$(base.all:%=docker.%): FINAL_TAG=$(GIT_VERSION)-$(base.each:docker.%=%)
+$(base.all:%=docker.%): FINAL_TAG=$(VERSION)-$(base.each:docker.%=%)
 $(base.all:%=docker.push.%): BASE_IMAGE=$($(base.each:docker.push.%=base.image.%))
-$(base.all:%=docker.push.%): FINAL_TAG=$(GIT_VERSION)-$(base.each:docker.push.%=%)
-$(base.all:%=docker.%) $(base.all:%=docker.push.%):
+$(base.all:%=docker.push.%): FINAL_TAG=$(VERSION)-$(base.each:docker.push.%=%)
+$(base.all:%=docker.%) $(base.all:%=docker.push.%): version-check
+	@$(version-check)
 	@$(LOG_TARGET)
 	docker buildx create --use --driver docker-container --name skywalking_go > /dev/null 2>&1 || true
 	docker buildx build $(PLATFORMS) $(LOAD_OR_PUSH) \
         --no-cache \
         --build-arg "BASE_GO_IMAGE=$(BASE_IMAGE)" \
-        --build-arg "VERSION=$(GIT_VERSION)" \
+        --build-arg "BASE_BUILDER_IMAGE=$(BASE_IMAGE)" \
+        --build-arg "VERSION=$(VERSION)" \
         . -t $(HUB)/$(PROJECT):$(FINAL_TAG)
 	docker buildx rm skywalking_go || true
 

--- a/tools/go-agent/Makefile
+++ b/tools/go-agent/Makefile
@@ -29,7 +29,7 @@ GIT_COMMIT := $(shell $(GIT) rev-parse --short HEAD)
 ifeq ($(strip $(GIT_COMMIT)),)
     GIT_COMMIT = $(shell grep gitCommit $(VERSION_PATH) | awk -F ': ' '{print $$2}')
 endif
-VERSION := $(shell grep version $(VERSION_PATH) | awk -F ': ' '{print $$2}')
+VERSION ?= $(shell grep version $(VERSION_PATH) | awk -F ': ' '{print $$2}')
 
 GO_VERSION := $(shell $(GO) env GOVERSION)
 VERSION_PACKAGE := main
@@ -38,7 +38,7 @@ GO_PATH = $$($(GO) env GOPATH)
 GO_BUILD = $(GO) build
 GO_LINT = $(GO_PATH)/bin/golangci-lint
 GO_BUILD_FLAGS = -v
-GO_BUILD_LDFLAGS = -X $(VERSION_PACKAGE).version=$(VERSION) -X $(VERSION_PACKAGE).goVersion=$(GO_VERSION) -X $(VERSION_PACKAGE).gitCommit=$(GIT_COMMIT)
+GO_BUILD_LDFLAGS = -X $(VERSION_PACKAGE).version=$(VERSION) -X $(VERSION_PACKAGE).gitCommit=$(GIT_COMMIT)
 GO_TEST_LDFLAGS =
 GO_GET = $(GO) get
 

--- a/tools/go-agent/cmd/helper.go
+++ b/tools/go-agent/cmd/helper.go
@@ -20,12 +20,12 @@ package main
 import (
 	"fmt"
 	"os"
+	"runtime"
 	"text/template"
 )
 
 var (
 	version   string
-	goVersion string
 	gitCommit string
 )
 
@@ -55,7 +55,7 @@ func PrintVersion() {
 	versionInfo := map[string]any{
 		"Version":   version,
 		"GitCommit": gitCommit,
-		"GoVersion": goVersion,
+		"GoVersion": runtime.Version(),
 	}
 	if err := versionTmpl.Execute(os.Stdout, versionInfo); err != nil {
 		fmt.Fprintln(os.Stdout, err)


### PR DESCRIPTION
When I tried to push the docker image, found the image names always start with git version instant of version, so I fixed it in this PR. 