### PR TITLE
Fix cannot find file when exec build in test/plugins

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,6 +21,7 @@ Release Notes.
 #### Bug Fixes
 * Fix wrong docker image name and `-version` command.
 * Fix redis plugin cannot work in cluster mode.
+* Fix cannot find file when exec build in test/plugins.
 
 #### Issues and PR
 - All issues are [here](https://github.com/apache/skywalking/milestone/219?closed=1)

--- a/test/plugins/Makefile
+++ b/test/plugins/Makefile
@@ -18,12 +18,18 @@
 GO = go
 GO_BUILD = $(GO) build
 
+GIT_VERSION := $(shell git rev-parse --short HEAD)
+ifeq ($(strip $(GIT_VERSION)),)
+    GIT_VERSION = $(shell grep gitCommit $(VERSION_FILE) | awk -F ': ' '{print $$2}')
+endif
+VERSION ?= $(GIT_VERSION)
+
 .PHONY: build
 build:
 	mkdir -p dist
 	# go agent
 	@make -C ../../tools/go-agent linux
-	cp ../../bin/skywalking-go-agent--linux-$(shell go env GOARCH) dist/skywalking-go-agent
+	cp ../../bin/skywalking-go-agent-$(VERSION)-linux-$(shell go env GOARCH) dist/skywalking-go-agent
 	# runner helper
 	cd runner-helper && $(GO_BUILD) -o ../dist/runner-helper
 	# validator container

--- a/tools/go-agent/Makefile
+++ b/tools/go-agent/Makefile
@@ -30,6 +30,9 @@ ifeq ($(strip $(GIT_COMMIT)),)
     GIT_COMMIT = $(shell grep gitCommit $(VERSION_PATH) | awk -F ': ' '{print $$2}')
 endif
 VERSION ?= $(shell grep version $(VERSION_PATH) | awk -F ': ' '{print $$2}')
+ifeq ($(strip $(VERSION)),)
+    VERSION = $(GIT_COMMIT)
+endif
 
 GO_VERSION := $(shell $(GO) env GOVERSION)
 VERSION_PACKAGE := main


### PR DESCRIPTION
When the VERSION of the root directory is not empty, executing make build in test/plugins will cannot find the binary file.