### PR TITLE
Refactor: Replace emptyReporter with DiscardReporter

### DIFF
--- a/plugins/core/reporter/discard_reporter.go
+++ b/plugins/core/reporter/discard_reporter.go
@@ -39,7 +39,7 @@ func (r *discardReporter) SendLog(log *logv3.LogData) {
 }
 func (r *discardReporter) ConnectionStatus() ConnectionStatus {
 	// do nothing
-	return 0
+	return ConnectionStatusDisconnect
 }
 func (r *discardReporter) Close() {
 	// do nothing

--- a/plugins/core/reporter/discard_reporter_test.go
+++ b/plugins/core/reporter/discard_reporter_test.go
@@ -31,8 +31,8 @@ func TestDiscardReporter(t *testing.T) {
 	r.SendTracing(nil)
 	r.SendMetrics(nil)
 	r.SendLog(nil)
-	if status := r.ConnectionStatus(); status != 0 {
-		t.Errorf("expect 0, actual is %d", status)
+	if status := r.ConnectionStatus(); status != reporter.ConnectionStatusDisconnect {
+		t.Errorf("expect 2, actual is %d", status)
 	}
 	r.Close()
 }

--- a/plugins/core/tracer.go
+++ b/plugins/core/tracer.go
@@ -27,8 +27,6 @@ import (
 
 	"github.com/apache/skywalking-go/plugins/core/operator"
 	"github.com/apache/skywalking-go/plugins/core/reporter"
-
-	logv3 "skywalking.apache.org/repo/goapi/collect/logging/v3"
 )
 
 // nolint
@@ -111,7 +109,7 @@ func NewEntity(service, instanceEnvName string) *reporter.Entity {
 func newTracer() *Tracer {
 	return &Tracer{
 		initFlag:    0,
-		Reporter:    &emptyReporter{},
+		Reporter:    reporter.NewDiscardReporter(),
 		Sampler:     NewConstSampler(false),
 		Log:         &LogWrapper{newDefaultLogger()},
 		cdsWatchers: make([]reporter.AgentConfigChangeWatcher, 0),
@@ -127,33 +125,6 @@ func (t *Tracer) InitSuccess() bool {
 
 func (t *Tracer) ChangeLogger(logger interface{}) {
 	t.Log.ChangeLogger(logger.(operator.LogOperator))
-}
-
-// nolint
-type emptyReporter struct{}
-
-// nolint
-func (e *emptyReporter) Boot(entity *reporter.Entity, cdsWatchers []reporter.AgentConfigChangeWatcher) {
-}
-
-// nolint
-func (e *emptyReporter) SendTracing(spans []reporter.ReportedSpan) {
-}
-
-// nolint
-func (e *emptyReporter) SendMetrics(metrics []reporter.ReportedMeter) {
-}
-
-// nolint
-func (e *emptyReporter) SendLog(log *logv3.LogData) {
-}
-
-func (e *emptyReporter) ConnectionStatus() reporter.ConnectionStatus {
-	return reporter.ConnectionStatusDisconnect
-}
-
-// nolint
-func (e *emptyReporter) Close() {
 }
 
 type LogWrapper struct {


### PR DESCRIPTION
## Purpose
This PR replaces the custom `emptyReporter` implementation in `plugins/core/tracer.go` with the existing `reporter.NewDiscardReporter()` to reduce code duplication and improve maintainability.

## Changes
- Replace `&emptyReporter{}` with `reporter.NewDiscardReporter()` in the `newTracer()` method
- Remove the redundant `emptyReporter` struct and its method implementations

## Motivation and Context
The `emptyReporter` and `DiscardReporter` have identical functionality - they both implement the Reporter interface but don't perform any actual operations. Using the existing `DiscardReporter` implementation reduces code duplication and follows the DRY principle.