### PR TITLE
Remove defer unlock when goroutine change

### DIFF
--- a/plugins/core/context.go
+++ b/plugins/core/context.go
@@ -57,11 +57,12 @@ func (t *TracingContext) TakeSnapShot() interface{} {
 
 func (t *TracingContext) ActiveSpan() TracingSpan {
 	t.activeSpanLock.RLock()
-	defer t.activeSpanLock.RUnlock()
-	if t.activeSpan == nil || reflect.ValueOf(t.activeSpan).IsZero() {
+	data := t.activeSpan
+	t.activeSpanLock.RUnlock()
+	if data == nil || reflect.ValueOf(data).IsZero() {
 		return nil
 	}
-	return t.activeSpan
+	return data
 }
 
 func (t *TracingContext) SaveActiveSpan(s TracingSpan) {


### PR DESCRIPTION
Since the Go agent adds a new goroutine to the tracing snapshot during `new_proc1`, it uses a defer statement to perform the unlock operation. However, because `new_proc1` returns a new goroutine, it differs from the one executing the defer statement, which leads to a fatal error.