### PR TITLE
Fix nil panic caused by Logrus not being initialized due to init execution order

### DIFF
--- a/tools/go-agent/instrument/logger/context.go
+++ b/tools/go-agent/instrument/logger/context.go
@@ -80,7 +80,6 @@ func (span *NoopSpan) GetEndPointName() string {
 
 func GetLogContext(withEndpoint bool) interface{} {
 	operator := GetOperator()
-	// 这里增加nil校验
 	if operator == nil {
 		return nil
 	}

--- a/tools/go-agent/instrument/logger/frameworks/logrus_adapt.go
+++ b/tools/go-agent/instrument/logger/frameworks/logrus_adapt.go
@@ -22,7 +22,7 @@ import (
 )
 
 func UpdateLogrusLogger(l *logrus.Logger) {
-	// 添加保护性检查，防止在Go 1.24中由于init顺序变更导致的nil panic
+	// Add a safeguard check to prevent nil panic caused by changes in init execution order
 	if l == nil {
 		return
 	}
@@ -33,7 +33,6 @@ func UpdateLogrusLogger(l *logrus.Logger) {
 		}
 	}
 
-	// 确保ChangeLogger不是nil
 	if ChangeLogger != nil {
 		ChangeLogger(NewLogrusAdapter(l))
 	}


### PR DESCRIPTION
**Changes**

Added nil check in 

- tools/go-agent/instrument/logger/context.go
- tools/go-agent/instrument/logger/frameworks/logrus_adapt.go

**Reason for Change**

Our project worked normally with Go 1.21 + go-agent v0.4.

After upgrading to Go 1.24 + go-agent v0.6, it compiled successfully but crashed with a nil panic at startup.

Investigation showed that the panic occurred because Logrus was accessed during initialization (init), while the underlying WrapFormat called GetLogContext before Logrus was fully initialized.

Full investigation details are documented on my blog: https://lymboy.com/archives/go-skywalking-agent-logrus-nil-panic