### PR TITLE
chore: fix function name in comment to match actual function

### DIFF
--- a/plugins/core/tracing/api.go
+++ b/plugins/core/tracing/api.go
@@ -169,7 +169,7 @@ func GetCorrelationContextValue(key string) string {
 	return op.Tracing().(operator.TracingOperator).GetCorrelationContextValue(key)
 }
 
-// SetRuntimeContextValue sets the value of the key in the correlation context.
+// SetCorrelationContextValue sets the value of the key in the correlation context.
 func SetCorrelationContextValue(key, val string) {
 	op := operator.GetOperator()
 	if op != nil {


### PR DESCRIPTION
fix function name in comment to match actual function