### PR TITLE
Fix publish-docker startup failure: repin docker/login-action to an approved SHA

### DIFF
--- a/.github/workflows/publish-docker.yaml
+++ b/.github/workflows/publish-docker.yaml
@@ -39,7 +39,7 @@ jobs:
         with:
           submodules: true
       - name: Log in to the Container registry
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ${{ env.HUB }}
           username: ${{ github.actor }}


### PR DESCRIPTION
### Fix the `publish-docker` workflow startup failure on `main`

The `publish-docker` workflow (which builds + pushes the agent base images on every push to `main`) [fails to start](https://github.com/apache/skywalking-go/actions/runs/27661274040) with `startup_failure` since the latest merge, so the Go 1.24/1.25/1.26 base images were not published.

Cause: the pinned `docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9` (v2-era, 2023) is **no longer on Apache INFRA's approved third-party GitHub Actions list**, so the run is rejected before it starts. (It worked previously; Apache has since rotated the approved SHAs.)

Fix: repin to `docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee` (**v4.2.0**), which is on the [approved list](https://github.com/apache/infrastructure-actions/blob/main/approved_patterns.yml). Inputs (`registry`/`username`/`password`) are unchanged across v2→v4.

- [x] No `CHANGES` entry needed (CI-only infra fix).